### PR TITLE
feat: Remove yarn install from the deploy action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           aws-region: eu-west-1
 
       - name: Check S3 Cache
-        uses: pleo-oss/pleo-spa-cicd/actions/s3-cache@v1.2.0
+        uses: pleo-oss/pleo-spa-cicd/actions/s3-cache@v1.3.0
         id: s3-cache
         with:
           bucket_name: ${{ inputs.bucket_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,12 +120,12 @@ jobs:
            --exclude "static/*"
 
       - name: Update Cursor File
-        uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v1.2.0
+        uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v1.3.0
         with:
           bucket_name: ${{ inputs.bucket_name }}
 
       - name: Update PR Description
-        uses: pleo-oss/pleo-spa-cicd/actions/post-preview-urls@v1.2.0
+        uses: pleo-oss/pleo-spa-cicd/actions/post-preview-urls@v1.3.0
         if: github.event_name == 'pull_request'
         with:
           domain: ${{ inputs.domain_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,9 +54,6 @@ on:
         required: true
         description:
           "Secret of a AWS key that allows read access to the registry bucket"
-      GH_REGISTRY_NPM_TOKEN:
-        required: true
-        description: "Token for NPM package registry"
     outputs:
       deployment_url:
         description: "URL where the deployment can be accessed"
@@ -103,15 +100,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
-
-      - name: Install Dependencies
-        uses: bahmutov/npm-install@v1.7.11
-        if: inputs.apply_config
-        with:
-          useRollingCache: true
-          install-command: yarn --frozen-lockfile --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
 
       - name: Apply Environment Config
         if: inputs.apply_config

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 💡 A collection of reusable GitHub Actions and Workflows helpful while building
 a complete CI/CD pipeline for a Single Page Application using the cursor files.
 
-👨‍🔧 This repo is lovingly stewarded by Pleo Frontend Ops.
+👨‍🔧 This repository is lovingly stewarded by Pleo Frontend Ops.
 
 🐛 Issues should be reported
-[in the repo](https://github.com/pleo-oss/pleo-spa-cicd/issues) or via
+[in the repository](https://github.com/pleo-oss/pleo-spa-cicd/issues) or via
 [Stewards: Frontend Infrastructure](https://linear.app/pleo/project/stewards-spa-cicd-and-infra-53a0a536f855)
 project on Linear (if you have access).
 
@@ -21,4 +21,13 @@ project on Linear (if you have access).
 
 This repo uses Semantic Release to version the changes and keep an up-to-date
 changelog file. When creating a PR, make sure that the squash commit title
-follows the semantic commit standards.
+(i.e. the PR title) follows the semantic commit standards.
+
+Due to GitHub reusable workflow limitations, any changes needs to be made on
+the [pleo-oss/pleo-spa-cicd](https://github.com/pleo-oss/pleo-spa-cicd)
+repository, but after merging to `main` the changes are manually mirrored to
+[pleo-io/pleo-spa-cicd](https://github.com/pleo-io/pleo-spa-cicd) by running:
+
+```sh
+git push --mirror https://github.com/pleo-io/pleo-spa-cicd
+```

--- a/actions/README.md
+++ b/actions/README.md
@@ -20,3 +20,7 @@ Each action is written in TypeScript and bundled into a single JS file using
 repo, so you need to run the build locally and include the changes to the built actions in your PR.
 
 To build the actions, run `make build`. Tests, written in Jest, you can run them with `make test`.
+
+Currently we need to manually update the version (to the next version) for actions in the
+`.workflows` folder. `git grep 'pleo.*@v' .github/workflows/*.yml` will highligh the places to
+change.


### PR DESCRIPTION
Remove `yarn install` from the deploy action and add additional documentation around developing.

Related:
- https://linear.app/pleo/issue/FOPS-57/github-reusable-workflows-enterprise-limitation-bonanza
- https://linear.app/pleo/issue/FOPS-8/optimise-deploy-workflow-to-avoid-installing-all-dependencies
