### PR TITLE
feat: Auto update actions version

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -30,4 +30,5 @@ jobs:
         with:
           extra_plugins: |
             @semantic-release/changelog
+            @semantic-release/exec
             @semantic-release/git

--- a/.releaserc
+++ b/.releaserc
@@ -13,10 +13,17 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "node ./scripts/prepare-publish.js ${nextRelease.version}"
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": [
-          "CHANGELOG.md"
+          "CHANGELOG.md",
+          ".github/workflows/*.yml"
         ]
       }
     ]

--- a/actions/README.md
+++ b/actions/README.md
@@ -20,7 +20,3 @@ Each action is written in TypeScript and bundled into a single JS file using
 repo, so you need to run the build locally and include the changes to the built actions in your PR.
 
 To build the actions, run `make build`. Tests, written in Jest, you can run them with `make test`.
-
-Currently we need to manually update the version (to the next version) for actions in the
-`.workflows` folder. `git grep 'pleo.*@v' .github/workflows/*.yml` will highligh the places to
-change.

--- a/scripts/prepare-publish.js
+++ b/scripts/prepare-publish.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+const nextVersion = process.argv[2];
+
+if (!nextVersion) {
+  throw new Error(`Expected version as an argument`);
+}
+
+const directoryPath = path.join(__dirname, "../.github/workflows");
+
+fs.readdirSync(directoryPath)
+  .filter((f) => f.endsWith(".yml"))
+  .forEach(function (ymlFileName) {
+    const filePath = path.join(directoryPath, ymlFileName);
+
+    console.log(`${ymlFileName}: searching for out-dated actions version`);
+
+    const existingContent = fs.readFileSync(filePath, "utf8");
+    const newContent = existingContent.replace(
+      /(pleo-oss\/pleo-spa-cicd\/actions.*@)(.*)/g,
+      `$1${nextVersion}`
+    );
+
+    if (existingContent !== newContent) {
+      console.log(`${ymlFileName}: patching version`);
+      fs.writeFileSync(filePath, newContent);
+    }
+  });


### PR DESCRIPTION
This should automatically update the `.github/workflow` files with the correct version once we merge a PR. 

NOTE that this will only work if we have set up a [personal access tokens](https://github.community/t/refusing-to-allow-a-github-app-to-create-or-update-workflow-without-workflows-permission/182573), else the job would fail with:

> ' ! [remote rejected] HEAD -> main (refusing to allow a GitHub App to create or update workflow `.github/workflows/build.yml` without `workflows` permission)\n' +
