### PR TITLE
feat: Use the new GitHub reusable workflow secret inherit feature

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,11 +41,15 @@ uploads the result to an S3 registry bucket.
 
 #### Secrets
 
-| Name                             | Description                                                       | Required |
-| -------------------------------- | ----------------------------------------------------------------- | :------: |
-| `AWS_ACCESS_KEY_ID_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket     |   yes    |
-| `AWS_SECRET_ACCESS_KEY_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket |   yes    |
-| `GH_REGISTRY_NPM_TOKEN`          | Token for NPM package registry                                    |   yes    |
+Use the
+[`secrets: inherit`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit)
+options when using the workflow.
+
+| Name                                      | Description                                                       | Required |
+| ----------------------------------------- | ----------------------------------------------------------------- | :------: |
+| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket     |   yes    |
+| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket |   yes    |
+| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                    |   yes    |
 
 #### Outputs
 
@@ -58,17 +62,13 @@ uploads the result to an S3 registry bucket.
 
 ```yml
 build:
-  uses: pleo-oss/pleo-spa-cicd/workflows/build.yml@v1
+  uses: pleo-oss/pleo-spa-cicd/workflows/build.yml@v2
+  secrets: inherit
   with:
     app_name: my-app
     build_script: build:app
     build_dir: dist
     bucket_name: my-registry-bucket
-  secrets:
-    GH_REGISTRY_NPM_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
-    AWS_ACCESS_KEY_ID_REGISTRY: ${{ secrets.AWS_ACCESS_KEY_ID_REGISTRY }}
-    AWS_SECRET_ACCESS_KEY_REGISTRY:
-      ${{ secrets.AWS_SECRET_ACCESS_KEY_REGISTRY }}
 ```
 
 ### Deploy
@@ -90,13 +90,16 @@ the cursor file for the current branch.
 
 #### Secrets
 
-| Name                             | Description                                                        | Required |
-| -------------------------------- | ------------------------------------------------------------------ | :------: |
-| `AWS_ACCESS_KEY_ID_REGISTRY`     | ID of a AWS key that allows read access to the registry bucket     |   yes    |
-| `AWS_SECRET_ACCESS_KEY_REGISTRY` | Secret of a AWS key that allows read access to the registry bucket |   yes    |
-| `AWS_ACCESS_KEY_ID_ORIGIN`       | ID of a AWS key that allows r/w access to the origin bucket        |   yes    |
-| `AWS_SECRET_ACCESS_KEY_ORIGIN`   | Secret of a AWS key that allows r/w access to the origin bucket    |   yes    |
-| `GH_REGISTRY_NPM_TOKEN`          | Token for NPM package registry                                     |   yes    |
+Use the
+[`secrets: inherit`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit)
+options when using the workflow.
+
+| Name                                      | Description                                                        | Required |
+| ----------------------------------------- | ------------------------------------------------------------------ | :------: |
+| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows read access to the registry bucket     |   yes    |
+| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows read access to the registry bucket |   yes    |
+| `AWS_ACCESS_KEY_ID_ORIGIN`                | ID of a AWS key that allows r/w access to the origin bucket        |   yes    |
+| `AWS_SECRET_ACCESS_KEY_ORIGIN`            | Secret of a AWS key that allows r/w access to the origin bucket    |   yes    |
 
 #### Outputs
 
@@ -108,8 +111,9 @@ the cursor file for the current branch.
 
 ```yml
 deploy:
-  uses: pleo-oss/pleo-spa-cicd/workflows/deploy.yml@v1
+  uses: pleo-oss/pleo-spa-cicd/workflows/deploy.yml@v2
   needs: build
+  secrets: inherit
   with:
     environment: staging
     bundle_uri: ${{ needs.build.outputs.bundle_uri }}
@@ -117,11 +121,4 @@ deploy:
     bucket_name: my-origin-bucket
     domain_name: app.staging.example.com
     apply_config: true
-  secrets:
-    GH_REGISTRY_NPM_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
-    AWS_ACCESS_KEY_ID_ORIGIN: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    AWS_SECRET_ACCESS_KEY_ORIGIN: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    AWS_ACCESS_KEY_ID_REGISTRY: ${{ secrets.AWS_ACCESS_KEY_ID_REGISTRY }}
-    AWS_SECRET_ACCESS_KEY_REGISTRY:
-      ${{ secrets.AWS_SECRET_ACCESS_KEY_REGISTRY }}
 ```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,18 +26,6 @@ on:
         default: "@pleo-io"
         description: "Org scope for the GitHub Package Registry"
         type: string
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        description:
-          "ID of a AWS key that allows r/w access to the registry bucket"
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        description:
-          "Secret of a AWS key that allows r/w access to the registry bucket"
-        required: true
-      GH_REGISTRY_NPM_TOKEN:
-        required: true
-        description: "Token for NPM package registry"
     outputs:
       tree_hash:
         description: "Tree hash of the code built"
@@ -57,8 +45,9 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
+          aws-secret-access-key:
+            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - name: Check S3 Cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,23 +37,6 @@ on:
         default: "@pleo-io"
         description: "Org scope for the GitHub Package Registry"
         type: string
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-        description:
-          "ID of a AWS key that allows r/w access to the origin bucket"
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-        description:
-          "Secret of a AWS key that allows r/w access to the origin bucket"
-      AWS_ACCESS_KEY_ID_REGISTRY:
-        required: true
-        description:
-          "ID of a AWS key that allows read access to the registry bucket"
-      AWS_SECRET_ACCESS_KEY_REGISTRY:
-        required: true
-        description:
-          "Secret of a AWS key that allows read access to the registry bucket"
     outputs:
       deployment_url:
         description: "URL where the deployment can be accessed"
@@ -85,8 +68,9 @@ jobs:
       - name: Setup AWS Credentials for Registry Bucket Access
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_REGISTRY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_REGISTRY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
+          aws-secret-access-key:
+            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - name: Download & Unpack Bundle


### PR DESCRIPTION
BREAKING CHANGE: The reusable workflow need to be used with secrets: inherit option

This a new feature for GH reusable workflows, announced here: https://github.blog/changelog/2022-05-03-github-actions-simplify-using-secrets-with-reusable-workflows/ and documented here https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow