### PR TITLE
feat: Upload deployed artifact for debugging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,5 +119,5 @@ jobs:
       - name: Upload Deployed Bundle as Artifact
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: bundle
+          name: bundle-${{ inputs.tree_hash }}
           path: bundle.tar.gz


### PR DESCRIPTION
In order to better understand what was deployed, it's nice to be able to inspect the built bundle. With this change, it will be uploaded as an artifact of the workflow run