### PR TITLE
feat: Inversion of control for how injecting config works in deploy workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -85,6 +85,7 @@ the cursor file for the current branch.
 | `bucket_name`       | Name of the S3 origin bucket                    | `string` | n/a        |   yes    |
 | `domain_name`       | Domain name for the app (e.g. app.example.com)  | `string` | n/a        |   yes    |
 | `inject_config_cmd` | Command to run to inject the environment config | `string` | n/a        |    no    |
+| `bundle_dir`        | Directory where the bundle should be unpacked   | `string` | `dist`     |    no    |
 | `registry_scope`    | Org scope for the GitHub Package Registry       | `string` | `@pleo-io` |    no    |
 
 #### Secrets

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,10 +13,10 @@ criteria:
   production version, i.e. a bundle without any baked-in configuration that
   differs between environments. The way to accomplish this will vary depending
   on the build tooling you use.
-- if your SPA is deployed to different environments you need to provide a a
-  command which can inject the config for a selected environment into the
-  bundle. If provided, this workflow will invoke that command before uploading
-  files to S3
+- if your SPA is deployed to different environments, you need to provide a
+  command which can inject the config for the selected environment into the
+  bundle. If provided, the deploy workflow will invoke that command before
+  uploading files to S3
 - all the long-cacheable assets like JS/CSS/images need to have a cache buster
   string in their name and they need to be placed in a `${build_dir}/static`
   directory when the production version is built.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,11 +13,10 @@ criteria:
   production version, i.e. a bundle without any baked-in configuration that
   differs between environments. The way to accomplish this will vary depending
   on the build tooling you use.
-- if your SPA is deployed to different environments you need to provide a
-  `apply:config` script in `package.json` which can inject the config for a
-  selected environment into the bundle. This workflow will invoke the
-  `apply:config` passing 3 CLI arguments: the location of the bundle, the
-  environment and the tree hash (i.e. version) deployed.
+- if your SPA is deployed to different environments you need to provide a a
+  command which can inject the config for a selected environment into the
+  bundle. If provided, this workflow will invoke that command before uploading
+  files to S3
 - all the long-cacheable assets like JS/CSS/images need to have a cache buster
   string in their name and they need to be placed in a `${build_dir}/static`
   directory when the production version is built.
@@ -78,15 +77,15 @@ the cursor file for the current branch.
 
 #### Inputs
 
-| Name             | Description                                    | Type      | Default    | Required |
-| ---------------- | ---------------------------------------------- | --------- | ---------- | :------: |
-| `environment`    | Name of the deployment environment             | `string`  | n/a        |   yes    |
-| `bundle_uri`     | S3 URI of the bundle in the registry bucket    | `string`  | n/a        |   yes    |
-| `tree_hash`      | Tree hash of the code to deploy                | `string`  | n/a        |   yes    |
-| `bucket_name`    | Name of the S3 origin bucket                   | `string`  | n/a        |   yes    |
-| `domain_name`    | Domain name for the app (e.g. app.example.com) | `string`  | n/a        |   yes    |
-| `apply_config`   | Should apply:config npm script be ran          | `boolean` | `false`    |    no    |
-| `registry_scope` | Org scope for the GitHub Package Registry      | `string`  | `@pleo-io` |    no    |
+| Name                | Description                                     | Type     | Default    | Required |
+| ------------------- | ----------------------------------------------- | -------- | ---------- | :------: |
+| `environment`       | Name of the deployment environment              | `string` | n/a        |   yes    |
+| `bundle_uri`        | S3 URI of the bundle in the registry bucket     | `string` | n/a        |   yes    |
+| `tree_hash`         | Tree hash of the code to deploy                 | `string` | n/a        |   yes    |
+| `bucket_name`       | Name of the S3 origin bucket                    | `string` | n/a        |   yes    |
+| `domain_name`       | Domain name for the app (e.g. app.example.com)  | `string` | n/a        |   yes    |
+| `inject_config_cmd` | Command to run to inject the environment config | `string` | n/a        |    no    |
+| `registry_scope`    | Org scope for the GitHub Package Registry       | `string` | `@pleo-io` |    no    |
 
 #### Secrets
 
@@ -120,5 +119,5 @@ deploy:
     tree_hash: ${{ needs.build.outputs.tree_hash }}
     bucket_name: my-origin-bucket
     domain_name: app.staging.example.com
-    apply_config: true
+    inject_config_cmd: yarn apply:config --env staging
 ```

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,10 @@ on:
         required: true
         description: "Domain name for the app (e.g. app.example.com)"
         type: string
-      apply_config:
+      inject_config_cmd:
         required: false
-        description: "Should apply:config npm script be ran"
-        type: boolean
-        default: false
+        description: "Command to run to inject the environment config"
+        type: string
       registry_scope:
         required: false
         default: "@pleo-io"
@@ -85,10 +84,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
-      - name: Apply Environment Config
-        if: inputs.apply_config
-        run: |
-          yarn apply:config dist ${{ inputs.environment }} ${{ inputs.tree_hash }}
+      - name: Inject Environment Config
+        if: inputs.inject_config_cmd
+        run: ${{ inputs.inject_config_cmd }}
 
       - name: Copy Static Files
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,11 @@ on:
         required: true
         description: "S3 URI of the bundle in the registry bucket"
         type: string
+      bundle_dir:
+        required: false
+        default: "dist"
+        description: "Directory where the bundle should be unpacked"
+        type: string
       tree_hash:
         required: true
         description: "Tree hash of the code to deploy"
@@ -75,7 +80,7 @@ jobs:
       - name: Download & Unpack Bundle
         run: |
           aws s3 cp ${{ inputs.bundle_uri }} bundle.tar.gz
-          mkdir dist && tar -xvzf bundle.tar.gz -C dist
+          mkdir ${{ inputs.bundle_dir }} && tar -xvzf bundle.tar.gz -C ${{ inputs.bundle_dir }}
 
       - name: Setup AWS Credentials for Origin Bucket Access
         uses: aws-actions/configure-aws-credentials@v1
@@ -90,13 +95,13 @@ jobs:
 
       - name: Copy Static Files
         run: |
-          aws s3 cp dist/static s3://${{ inputs.bucket_name }}/static \
+          aws s3 cp ${{ inputs.bundle_dir }}/static s3://${{ inputs.bucket_name }}/static \
             --cache-control 'public,max-age=31536000,immutable' \
             --recursive
 
       - name: Copy HTML Files
         run: |
-          aws s3 cp dist/ s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }} \
+          aws s3 cp ${{ inputs.bundle_dir }}/ s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }} \
            --cache-control 'public,max-age=31536000,immutable' \
            --recursive \
            --exclude "static/*"


### PR DESCRIPTION
BREAKING CHANGE: Instead of passing a boolean input called "apply_config" that would cause the deploy workflow to run a predefined script in package.json, we now allow the workflow consumer to pass the entire command, including the parameters in order and fashion that fits the use-case best. This allows to pass additional arguments to those scripts, not related to cursor deployment, without the deploy workflow needing to support them explicitly.