### PR TITLE
feat: Verify deployment by checking for tree hash injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,3 +139,7 @@ jobs:
         with:
           name: bundle-${{ inputs.tree_hash }}
           path: bundle.tar.gz
+
+      - name: Verify app deployment
+        # We expect "Inject Environment Config" to insert the version in the HTML.
+        run: curl --silent --show-error ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.tree_hash }}


### PR DESCRIPTION
This would have caught the production deployment incident: 
https://www.notion.so/pleo/INC-147-Product-Web-deployment-stuck-1fc96ec7562b48b286f27994bc2104ff?pvs=4

Tested in https://github.com/pleo-io/product-web/pull/10377