### PR TITLE
fix: Upgrade aws-credentials (node 16 by default)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           echo "::set-output name=uri::s3://${{ inputs.bucket_name }}/bundles/${{ github.repository }}/${{ inputs.app_name }}/${{ steps.s3-cache.outputs.hash }}.tar.gz"
 
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
           echo "::set-output name=url::https://${SUBDOMAIN}${{ inputs.domain_name }}"
 
       - name: Setup AWS Credentials for Registry Bucket Access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key:
@@ -92,7 +92,7 @@ jobs:
           mkdir ${{ inputs.bundle_dir }} && tar -xvzf bundle.tar.gz -C ${{ inputs.bundle_dir }}
 
       - name: Setup AWS Credentials for Origin Bucket Access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/actions/.prettierignore
+++ b/actions/.prettierignore
@@ -1,3 +1,4 @@
 # Ignore artifacts:
 dist
 pnpm-lock.yaml
+CHANGELOG.md

--- a/actions/cursor-deploy/README.md
+++ b/actions/cursor-deploy/README.md
@@ -78,7 +78,7 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 10
-            - uses: aws-actions/configure-aws-credentials@v1
+            - uses: aws-actions/configure-aws-credentials@v2.0.0
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -102,7 +102,7 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v3
-            - uses: aws-actions/configure-aws-credentials@v1
+            - uses: aws-actions/configure-aws-credentials@v2.0.0
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           echo "::set-output name=uri::s3://${{ inputs.bucket_name }}/bundles/${{ github.repository }}/${{ inputs.app_name }}/${{ steps.s3-cache.outputs.hash }}.tar.gz"
 
-      - uses: aws-actions/configure-aws-credentials@v1.7.0
+      - uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key:

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
           echo "::set-output name=url::https://${SUBDOMAIN}${{ inputs.domain_name }}"
 
       - name: Setup AWS Credentials for Registry Bucket Access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key:
@@ -92,7 +92,7 @@ jobs:
           mkdir ${{ inputs.bundle_dir }} && tar -xvzf bundle.tar.gz -C ${{ inputs.bundle_dir }}
 
       - name: Setup AWS Credentials for Origin Bucket Access
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
https://linear.app/pleo/issue/WEB-367/use-environment-files-instead-of-save-state-command-in-gh-actions