### PR TITLE
feat: Enable using npx with private registry for config command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,9 +100,12 @@ jobs:
 
       - name: Inject Environment Config
         if: inputs.inject_config_cmd
-        run: |
-          SPA_BUNDLE_DIR=${{ inputs.bundle_dir }} SPA_ENV=${{inputs.environment}} SPA_TREE_HASH=${{ inputs.tree_hash}} \
-            ${{inputs.inject_config_cmd }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
+          SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
+          SPA_ENV: ${{inputs.environment}}
+          SPA_TREE_HASH: ${{ inputs.tree_hash}}
+        run: ${{inputs.inject_config_cmd }}
 
       - name: Copy Static Files
         run: |

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -100,9 +100,12 @@ jobs:
 
       - name: Inject Environment Config
         if: inputs.inject_config_cmd
-        run: |
-          SPA_BUNDLE_DIR=${{ inputs.bundle_dir }} SPA_ENV=${{inputs.environment}} SPA_TREE_HASH=${{ inputs.tree_hash}} \
-            ${{inputs.inject_config_cmd }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
+          SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
+          SPA_ENV: ${{inputs.environment}}
+          SPA_TREE_HASH: ${{ inputs.tree_hash}}
+        run: ${{inputs.inject_config_cmd }}
 
       - name: Copy Static Files
         run: |


### PR DESCRIPTION
Injects `NODE_AUTH_TOKEN` to the environment when running `inject_config_cmd`. Hopefully this allows us to us `npx` with a scoped package.