### PR TITLE
feat!: Support repos with multiple apps that inject config

### DIFF
--- a/config-inject/README.md
+++ b/config-inject/README.md
@@ -87,11 +87,12 @@ Configure the tool by adding a `spaConfig` namespace to your `package.json` file
 options are as follows:
 
 -   `configDir` (string, required): The location of your app configuration files.
--   `buildDir` (string, required): The location of the HTML template file.
+-   `buildDir` (string, required): The location of the HTML template file. Can be overridden with
+    `SPA_BUILD_DIR` env var
 -   `templateFileName` (string, optional, default: `_index.html`): The name of the template HTML
-    file (relative to build dir).
+    file (relative to build dir). Can be overridden with `SPA_TEMPLATE_FILE_NAME` env var
 -   `outputFileName` (string, optional, default: `index.html`): The name of the output HTML file
-    (relative to build dir).
+    (relative to build dir). Can be overridden with `SPA_OUTPUT_FILE_NAME` env var
 -   `devConfigOverrideFile` (string, optional, default: `config.dev.json`): The name of the
     development config override file.
 
@@ -101,14 +102,19 @@ To inject the dev config when running the app locally, add the Vite plugin to yo
 
 ```ts
 import {defineConfig} from 'vite'
-import {inlineDevelopmentConfig} from '@pleo-io/spa-config-inject/vite'
+import {inlineLocalConfig} from '@pleo-io/spa-config-inject/vite'
 
 export default defineConfig((config) => {
     return {
-        plugins: [inlineDevelopmentConfig(config)]
+        plugins: [inlineLocalConfig({isDisabled: config.mode === 'production'})]
     }
 })
 ```
+
+Options that can be passed to `inlineLocalConfig`:
+
+-   `isDisabled`: Disables the plugin - usually in production mode (defaults to false)
+-   `env`: The name of the environment for which the config is injected (defaults to `dev`)
 
 ## Dev overrides
 

--- a/config-inject/src/cli.ts
+++ b/config-inject/src/cli.ts
@@ -24,8 +24,11 @@ into the HTML template file.
 @param cliEnv - The environment of the config to inject, passed via CLI argument
 */
 async function run(cliEnv: string) {
-    const {buildDir, templateFileName, outputFileName, configDir} = await loadConfig()
+    const config = await loadConfig()
     const dynamicConfigJSON = process.env.SPA_CONFIG_OVERRIDE
+    const buildDir = process.env.SPA_BUILD_DIR ?? config.buildDir
+    const templateFileName = process.env.SPA_TEMPLATE_FILE_NAME ?? config.templateFileName
+    const outputFileName = process.env.SPA_OUTPUT_FILE_NAME ?? config.outputFileName
     const env = cliEnv ?? process.env.SPA_ENV
 
     assert(env, 'Provide the environment name as an option or via SPA_ENV env variable')
@@ -34,7 +37,7 @@ async function run(cliEnv: string) {
         buildDir,
         templateFileName,
         outputFileName,
-        configDir,
+        configDir: config.configDir,
         env,
         dynamicConfigJSON
     })

--- a/config-inject/src/vite.ts
+++ b/config-inject/src/vite.ts
@@ -17,7 +17,7 @@ const DEFAULT_ENV = 'dev'
 Inline runtime configuration during development.
 Inspiration: https://github.com/vitejs/vite/issues/3105
 @see https://vitejs.dev/guide/api-plugin.html#transformindexhtml
-@param config - The Vite config environment.
+@param config
 @param env - The name of the environment of the config inlined (defaults to "dev")
 @returns Returns a Vite plugin definition or null if in production mode.
 */


### PR DESCRIPTION
You can now override some of the config from package.json via env variables. You can also pass environment to the Vite plugin, to inject config file other than config.dev.mjs BREAKING CHANGE: inlineDevelopmentConfig was renamed to inlineLocalConfig to reflect the above. Options passed has also changed, see README.