### PR TITLE
feat: Add X-Pleo-SPA-Version header to the HTML response

### DIFF
--- a/terraform-module/edge-lambdas/dist/viewer-response/index.js
+++ b/terraform-module/edge-lambdas/dist/viewer-response/index.js
@@ -107,6 +107,7 @@ function getCookie(headers, cookieName) {
     }
     return null;
 }
+const APP_VERSION_HEADER = 'X-Pleo-SPA-Version';
 
 ;// CONCATENATED MODULE: external "@aws-sdk/client-s3"
 const client_s3_namespaceObject = require("@aws-sdk/client-s3");
@@ -162,7 +163,6 @@ var translations_awaiter = (undefined && undefined.__awaiter) || function (thisA
 
 
 const TRANSLATION_VERSION_HEADER = 'X-Translation-Version';
-const APP_VERSION_HEADER = 'X-App-Version';
 const DEFAULT_LANGUAGE = 'en';
 const LANG_QUERY_PARAM = 'lang';
 const LANG_COOKIE_NAME = 'x-pleo-language';
@@ -208,14 +208,13 @@ function addTranslationInfoToResponse(response, request, config) {
  * object as custom headers. This allows the viewer-response lambda to pick up this information
  * and use it enrich the response.
  */
-function addTranslationInfoToRequest({ request, translationVersion, appVersion, config }) {
+function addTranslationInfoToRequest({ request, translationVersion, config }) {
     if (!config.isLocalised) {
         return;
     }
     if (translationVersion) {
         request.headers = setHeader(request.headers, TRANSLATION_VERSION_HEADER, translationVersion);
     }
-    request.headers = setHeader(request.headers, APP_VERSION_HEADER, appVersion);
 }
 /**
  * Adds a cookie with the current translation version. This value is used by the app to request
@@ -305,6 +304,7 @@ function getHandler(config) {
         response = addSecurityHeaders(response, config);
         response = addCacheHeader(response);
         response = addRobotsHeader(response, config);
+        response = addVersionHeader(response, request);
         response = addTranslationInfoToResponse(response, request, config);
         return response;
     });
@@ -348,6 +348,13 @@ const addRobotsHeader = (response, config) => {
     }
     return Object.assign(Object.assign({}, response), { headers });
 };
+// Add a custom version header to the response (used e.g. for checking for new SPA versions)
+// Version is retrieved from a header set on request by the viewer-request lambda
+function addVersionHeader(response, request) {
+    const appVersion = getHeader(request, APP_VERSION_HEADER);
+    let headers = utils_setHeader(response.headers, APP_VERSION_HEADER, appVersion);
+    return Object.assign(Object.assign({}, response), { headers });
+}
 
 ;// CONCATENATED MODULE: ./src/viewer-response/index.ts
 

--- a/terraform-module/edge-lambdas/src/addons/translations.ts
+++ b/terraform-module/edge-lambdas/src/addons/translations.ts
@@ -11,11 +11,10 @@
 import {CloudFrontRequest, CloudFrontResponse} from 'aws-lambda'
 import {S3Client} from '@aws-sdk/client-s3'
 import {Config} from '../config'
-import {getCookie, getHeader, setHeader} from '../utils'
+import {APP_VERSION_HEADER, getCookie, getHeader, setHeader} from '../utils'
 import {fetchFileFromS3Bucket} from '../s3'
 
 const TRANSLATION_VERSION_HEADER = 'X-Translation-Version'
-const APP_VERSION_HEADER = 'X-App-Version'
 const DEFAULT_LANGUAGE = 'en'
 const LANG_QUERY_PARAM = 'lang'
 const LANG_COOKIE_NAME = 'x-pleo-language'
@@ -75,12 +74,10 @@ export function addTranslationInfoToResponse(
 export function addTranslationInfoToRequest({
     request,
     translationVersion,
-    appVersion,
     config
 }: {
     request: CloudFrontRequest
     translationVersion: string
-    appVersion: string
     config: Config
 }) {
     if (!config.isLocalised) {
@@ -90,7 +87,6 @@ export function addTranslationInfoToRequest({
     if (translationVersion) {
         request.headers = setHeader(request.headers, TRANSLATION_VERSION_HEADER, translationVersion)
     }
-    request.headers = setHeader(request.headers, APP_VERSION_HEADER, appVersion)
 }
 
 /**

--- a/terraform-module/edge-lambdas/src/utils.ts
+++ b/terraform-module/edge-lambdas/src/utils.ts
@@ -59,3 +59,5 @@ export function getCookie(headers: CloudFrontHeaders, cookieName: string) {
 
     return null
 }
+
+export const APP_VERSION_HEADER = 'X-Pleo-SPA-Version'

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.test.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.test.ts
@@ -28,14 +28,18 @@ describe(`Viewer request Lambda@Edge`, () => {
     `, async () => {
         const appVersion = getRandomSha()
         const host = 'app.example.com'
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const handler = getHandler({...originConfig}, mockS3)
         const request = await handler(event, mockContext, mockCallback)
 
         expectAppVersionFetched('deploys/master')
-        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${appVersion}/index.html`,
+            appVersion
+        })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
@@ -46,14 +50,18 @@ describe(`Viewer request Lambda@Edge`, () => {
     `, async () => {
         const appVersion = getRandomSha()
         const host = 'app.example.com'
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const handler = getHandler({...originConfig, defaultBranchName: 'main'}, mockS3)
         const request = await handler(event, mockContext, mockCallback)
 
         expectAppVersionFetched('deploys/main')
-        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${appVersion}/index.html`,
+            appVersion
+        })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
@@ -68,13 +76,17 @@ describe(`Viewer request Lambda@Edge`, () => {
             {...originConfig, previewDeploymentPostfix: '.app.staging.example.com'},
             mockS3
         )
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const request = await handler(event, mockContext, mockCallback)
 
         expectAppVersionFetched('deploys/master')
-        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${appVersion}/index.html`,
+            appVersion
+        })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
@@ -84,7 +96,7 @@ describe(`Viewer request Lambda@Edge`, () => {
     `, async () => {
         const appVersion = getRandomSha()
         const host = 'my-feature.app.staging.example.com'
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const handler = getHandler(
@@ -94,14 +106,18 @@ describe(`Viewer request Lambda@Edge`, () => {
         const request = await handler(event, mockContext, mockCallback)
 
         expectAppVersionFetched('deploys/my-feature')
-        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/index.html`})
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${appVersion}/index.html`,
+            appVersion
+        })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`Handles requests for specific html files`, async () => {
         const appVersion = getRandomSha()
         const host = 'my-feature.app.staging.example.com'
-        const event = mockRequestEvent({host, uri: '/iframe.html'})
+        const event = mockRequestEvent({host, uri: '/iframe.html', appVersion})
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const handler = getHandler(
@@ -111,14 +127,22 @@ describe(`Viewer request Lambda@Edge`, () => {
         const request = await handler(event, mockContext, mockCallback)
 
         expectAppVersionFetched('deploys/my-feature')
-        const expectedEvent = mockRequestEvent({host, uri: `/html/${appVersion}/iframe.html`})
+        const expectedEvent = mockRequestEvent({
+            host,
+            uri: `/html/${appVersion}/iframe.html`,
+            appVersion
+        })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
 
     test(`Handles requests for well known files`, async () => {
         const appVersion = getRandomSha()
         const host = 'my-feature.app.staging.example.com'
-        const event = mockRequestEvent({host, uri: '/.well-known/apple-app-site-association'})
+        const event = mockRequestEvent({
+            host,
+            uri: '/.well-known/apple-app-site-association',
+            appVersion
+        })
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const handler = getHandler(
@@ -133,7 +157,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         expectAppVersionFetched('deploys/my-feature')
         const expectedEvent = mockRequestEvent({
             host,
-            uri: `/html/${appVersion}/.well-known/apple-app-site-association`
+            uri: `/html/${appVersion}/.well-known/apple-app-site-association`,
+            appVersion
         })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
@@ -145,7 +170,7 @@ describe(`Viewer request Lambda@Edge`, () => {
         const appVersion = getRandomSha()
         const requestedAppVersion = getRandomSha()
         const host = `preview-${requestedAppVersion}.app.staging.example.com`
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
         mockedFetchFileFromS3Bucket.mockResolvedValue(appVersion)
 
         const handler = getHandler(
@@ -157,7 +182,8 @@ describe(`Viewer request Lambda@Edge`, () => {
         expect(mockedFetchFileFromS3Bucket).not.toHaveBeenCalled()
         const expectedEvent = mockRequestEvent({
             host,
-            uri: `/html/${requestedAppVersion}/index.html`
+            uri: `/html/${requestedAppVersion}/index.html`,
+            appVersion: requestedAppVersion
         })
         expect(request).toEqual(requestFromEvent(expectedEvent))
     })
@@ -171,7 +197,7 @@ describe(`Viewer request Lambda@Edge`, () => {
         const appVersion = getRandomSha()
         const translationVersion = getRandomInt()
         const host = 'app.example.com'
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
 
         mockedFetchFileFromS3Bucket.mockResolvedValueOnce(appVersion)
         mockedFetchFileFromS3Bucket.mockResolvedValueOnce(translationVersion)
@@ -197,7 +223,7 @@ describe(`Viewer request Lambda@Edge`, () => {
     `, async () => {
         const appVersion = getRandomSha()
         const host = 'app.example.com'
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion})
         jest.spyOn(console, 'error').mockImplementationOnce(() => {})
 
         mockedFetchFileFromS3Bucket.mockResolvedValueOnce(appVersion)
@@ -223,7 +249,7 @@ describe(`Viewer request Lambda@Edge`, () => {
     `, async () => {
         const host = 'what-is-this-branch.app.staging.example.com'
         jest.spyOn(console, 'error').mockImplementationOnce(() => {})
-        const event = mockRequestEvent({host})
+        const event = mockRequestEvent({host, appVersion: 'unknown'})
 
         mockedFetchFileFromS3Bucket.mockRejectedValueOnce(
             new Error(
@@ -238,7 +264,7 @@ describe(`Viewer request Lambda@Edge`, () => {
         const request = await handler(event, mockContext, mockCallback)
 
         expectAppVersionFetched('deploys/what-is-this-branch')
-        const expectedEvent = mockRequestEvent({host, uri: `/404`})
+        const expectedEvent = mockRequestEvent({host, uri: `/404`, appVersion: 'unknown'})
         expect(request).toEqual(requestFromEvent(expectedEvent))
         expect(console.error).toHaveBeenCalledTimes(1)
     })
@@ -256,7 +282,7 @@ const mockRequestEvent = ({
     uri = '/'
 }: {
     host: string
-    appVersion?: string
+    appVersion: string
     translationVersion?: string
     uri?: string
 }): CloudFrontRequestEvent => ({
@@ -298,10 +324,10 @@ const mockRequestEvent = ({
                                   }
                               ]
                             : undefined,
-                        'x-app-version': appVersion
+                        'x-pleo-spa-version': appVersion
                             ? [
                                   {
-                                      key: 'X-App-Version',
+                                      key: 'X-Pleo-SPA-Version',
                                       value: appVersion
                                   }
                               ]

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import {CloudFrontRequest, CloudFrontRequestHandler} from 'aws-lambda'
 import {S3Client} from '@aws-sdk/client-s3'
 
-import {getHeader} from '../utils'
+import {APP_VERSION_HEADER, getHeader, setHeader} from '../utils'
 import {fetchFileFromS3Bucket} from '../s3'
 import {Config} from '../config'
 import {addTranslationInfoToRequest, getTranslationVersion} from '../addons/translations'
@@ -43,8 +43,11 @@ export function getHandler(config: Config, s3: S3Client) {
                 getTranslationVersion(s3, config)
             ])
 
+            // Set app version header on request, so it can be picked up by the viewer response lambda
+            request.headers = setHeader(request.headers, APP_VERSION_HEADER, appVersion)
+
             // If needed, pass the versions to the viewer response lambda via custom headers on the request
-            addTranslationInfoToRequest({request, translationVersion, appVersion, config})
+            addTranslationInfoToRequest({request, translationVersion, config})
 
             // We instruct the CDN to return a file that corresponds to the app version calculated
             const uri = getUri(request, appVersion)

--- a/terraform-module/edge-lambdas/src/viewer-response/viewer-response.test.ts
+++ b/terraform-module/edge-lambdas/src/viewer-response/viewer-response.test.ts
@@ -15,7 +15,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         Then it adds security custom header to the response
         And it adds cache control custom header to the response
     `, async () => {
-        const event = mockResponseEvent({host: 'app.example.com'})
+        const appVersion = getRandomSha()
+        const event = mockResponseEvent({host: 'app.example.com', appVersion})
 
         const handler = getHandler(originConfig)
         const response = await handler(event, mockContext, mockCallback)
@@ -24,7 +25,7 @@ describe(`Viewer response Lambda@Edge`, () => {
             headers: {
                 ...securityHeaders,
                 ...cacheControlHeaders,
-                ...defaultHeaders
+                ...defaultHeaders(appVersion)
             },
             status: '200',
             statusDescription: 'OK'
@@ -35,7 +36,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         When blocking robots is turned on
         Then it adds robots custom header to the response
     `, async () => {
-        const event = mockResponseEvent({host: 'app.staging.example.com'})
+        const appVersion = getRandomSha()
+        const event = mockResponseEvent({host: 'app.staging.example.com', appVersion})
 
         const handler = getHandler({
             ...originConfig,
@@ -47,7 +49,7 @@ describe(`Viewer response Lambda@Edge`, () => {
         expect(response).toEqual({
             headers: {
                 ...securityHeaders,
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 'x-robots-tag': [{key: 'X-Robots-Tag', value: 'noindex, nofollow'}]
             },
@@ -60,7 +62,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         When blocking iFrames is turned on
         Then it adds frame blocking custom header to the response
     `, async () => {
-        const event = mockResponseEvent({host: 'app.staging.example.com'})
+        const appVersion = getRandomSha()
+        const event = mockResponseEvent({host: 'app.staging.example.com', appVersion})
 
         const handler = getHandler({
             ...originConfig,
@@ -73,7 +76,7 @@ describe(`Viewer response Lambda@Edge`, () => {
             headers: {
                 ...securityHeaders,
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders
             },
             status: '200',
@@ -91,7 +94,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         const translationVersion = getRandomInt()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            translations: {appVersion, translationVersion}
+            appVersion,
+            translationVersion
         })
 
         const handler = getHandler({
@@ -104,7 +108,7 @@ describe(`Viewer response Lambda@Edge`, () => {
         expect(response).toEqual({
             headers: {
                 ...securityHeaders,
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 ...getTranslationHeaders({
                     cookieHash: translationVersion,
@@ -122,7 +126,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         Then it does not add a preload header 
         And it does not add a translation cookie
     `, async () => {
-        const event = mockResponseEvent({host: 'app.staging.example.com'})
+        const appVersion = getRandomSha()
+        const event = mockResponseEvent({host: 'app.staging.example.com', appVersion})
 
         const handler = getHandler({
             ...originConfig,
@@ -134,7 +139,7 @@ describe(`Viewer response Lambda@Edge`, () => {
         expect(response).toEqual({
             headers: {
                 ...securityHeaders,
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders
             },
             status: '200',
@@ -148,11 +153,12 @@ describe(`Viewer response Lambda@Edge`, () => {
         And the custom language is used for the preload header
         And it adds a translation cookie using the translation version
     `, async () => {
-        const appVersion = getRandomSha()
         const translationVersion = getRandomInt()
+        const appVersion = getRandomSha()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            translations: {appVersion, translationVersion},
+            appVersion,
+            translationVersion,
             languageForCookie: 'da'
         })
 
@@ -166,7 +172,7 @@ describe(`Viewer response Lambda@Edge`, () => {
         expect(response).toEqual({
             headers: {
                 ...securityHeaders,
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 ...getTranslationHeaders({
                     cookieHash: translationVersion,
@@ -188,7 +194,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         const translationVersion = getRandomInt()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            translations: {appVersion, translationVersion},
+            appVersion,
+            translationVersion,
             languageForCookie: 'en'
         })
 
@@ -202,7 +209,7 @@ describe(`Viewer response Lambda@Edge`, () => {
         expect(response).toEqual({
             headers: {
                 ...securityHeaders,
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 ...getTranslationHeaders({
                     cookieHash: translationVersion,
@@ -223,7 +230,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         const translationVersion = getRandomInt()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            translations: {appVersion, translationVersion},
+            appVersion,
+            translationVersion,
             languageForParam: 'da'
         })
 
@@ -239,7 +247,7 @@ describe(`Viewer response Lambda@Edge`, () => {
             headers: {
                 ...securityHeaders,
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 ...getTranslationHeaders({
                     cookieHash: translationVersion,
@@ -260,7 +268,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         const translationVersion = getRandomInt()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            translations: {appVersion, translationVersion},
+            appVersion,
+            translationVersion,
             languageForParam: 'foo'
         })
 
@@ -276,7 +285,7 @@ describe(`Viewer response Lambda@Edge`, () => {
             headers: {
                 ...securityHeaders,
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 ...getTranslationHeaders({
                     cookieHash: translationVersion,
@@ -298,7 +307,8 @@ describe(`Viewer response Lambda@Edge`, () => {
         const translationVersion = getRandomInt()
         const event = mockResponseEvent({
             host: 'app.staging.example.com',
-            translations: {appVersion, translationVersion},
+            appVersion,
+            translationVersion,
             languageForParam: 'da',
             languageForCookie: 'fr'
         })
@@ -315,7 +325,7 @@ describe(`Viewer response Lambda@Edge`, () => {
             headers: {
                 ...securityHeaders,
                 'x-frame-options': [{key: 'X-Frame-Options', value: 'DENY'}],
-                ...defaultHeaders,
+                ...defaultHeaders(appVersion),
                 ...cacheControlHeaders,
                 ...getTranslationHeaders({
                     cookieHash: translationVersion,
@@ -329,10 +339,11 @@ describe(`Viewer response Lambda@Edge`, () => {
     })
 })
 
-const defaultHeaders = {
+const defaultHeaders = (appVersion: string) => ({
     'last-modified': [{key: 'Last-Modified', value: '2016-11-25'}],
-    'x-amz-meta-last-modified': [{key: 'X-Amz-Meta-Last-Modified', value: '2016-01-01'}]
-}
+    'x-amz-meta-last-modified': [{key: 'X-Amz-Meta-Last-Modified', value: '2016-01-01'}],
+    'x-pleo-spa-version': [{key: 'X-Pleo-SPA-Version', value: appVersion}]
+})
 
 const securityHeaders = {
     'x-content-type-options': [{key: 'X-Content-Type-Options', value: 'nosniff'}],
@@ -383,16 +394,15 @@ const getTranslationHeaders = ({
  */
 export const mockResponseEvent = ({
     host,
-    translations,
+    translationVersion,
+    appVersion,
     uri = '/',
     languageForCookie,
     languageForParam
 }: {
     host: string
-    translations?: {
-        appVersion: string
-        translationVersion?: string
-    }
+    appVersion: string
+    translationVersion?: string
     uri?: string
     languageForCookie?: string
     languageForParam?: string
@@ -415,18 +425,18 @@ export const mockResponseEvent = ({
                                 value: host
                             }
                         ],
-                        ...(translations
+                        'x-pleo-spa-version': [
+                            {
+                                key: 'X-Pleo-SPA-Version',
+                                value: appVersion
+                            }
+                        ],
+                        ...(translationVersion
                             ? {
                                   'x-translation-version': [
                                       {
                                           key: 'X-Translation-Version',
-                                          value: translations.translationVersion
-                                      }
-                                  ],
-                                  'x-app-version': [
-                                      {
-                                          key: 'X-App-Version',
-                                          value: translations.appVersion
+                                          value: translationVersion
                                       }
                                   ]
                               }
@@ -447,7 +457,7 @@ export const mockResponseEvent = ({
                 response: {
                     status: '200',
                     statusDescription: 'OK',
-                    headers: defaultHeaders
+                    headers: defaultHeaders(appVersion)
                 }
             }
         }


### PR DESCRIPTION
Adds the current app version to a custom header, so that we can run a `HEAD` request and get the latest version (e.g. for comparison with the currently loaded version and nudge the user towards refreshing).