### PR TITLE
feat: Add handling of well-known/apple-app-site-association

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,6 +124,10 @@ jobs:
            --recursive \
            --exclude "static/*"
 
+      - name: Post Upload Hook
+        if: inputs.post_upload_cmd
+        run: ${{inputs.post_upload_cmd }}
+
       - name: Update Cursor File
         id: cursor-update
         uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v8.0.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,10 @@ on:
         required: false
         description: "Command to run to inject the environment config"
         type: string
+      post_upload_cmd:
+        required: false
+        description: "Command to run after files were uploaded to S3"
+        type: string
       registry_scope:
         required: false
         default: "@pleo-io"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,10 +38,6 @@ on:
         required: false
         description: "Command to run to inject the environment config"
         type: string
-      post_upload_cmd:
-        required: false
-        description: "Command to run after files were uploaded to S3"
-        type: string
       registry_scope:
         required: false
         default: "@pleo-io"
@@ -124,9 +120,14 @@ jobs:
            --recursive \
            --exclude "static/*"
 
-      - name: Post Upload Hook
-        if: inputs.post_upload_cmd
-        run: ${{inputs.post_upload_cmd }}
+      - name: Update .well-known Files If Exists
+        run: |
+           aws s3 cp \
+            s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
+            s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
+            --content-type 'application/json' \
+            --cache-control 'public,max-age=3600' \
+            --metadata-directive REPLACE || echo "Failed updating .well-known files"
 
       - name: Update Cursor File
         id: cursor-update

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -88,7 +88,6 @@ the cursor file for the current branch.
 | `tree_hash`         | Tree hash of the code to deploy                 | `string` | n/a        |   yes    |
 | `bundle_dir`        | Directory where the bundle should be unpacked   | `string` | `dist`     |    no    |
 | `inject_config_cmd` | Command to run to inject the environment config | `string` | n/a        |    no    |
-| `post_upload_cmd`   | Command to run after files were uploaded to S3  | `string` | n/a        |    no    |
 | `registry_scope`    | Org scope for the GitHub Package Registry       | `string` | `@pleo-io` |    no    |
 
 #### Secrets

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -86,8 +86,9 @@ the cursor file for the current branch.
 | `tree_hash`         | Tree hash of the code to deploy                 | `string` | n/a        |   yes    |
 | `bucket_name`       | Name of the S3 origin bucket                    | `string` | n/a        |   yes    |
 | `domain_name`       | Domain name for the app (e.g. app.example.com)  | `string` | n/a        |   yes    |
-| `inject_config_cmd` | Command to run to inject the environment config | `string` | n/a        |    no    |
 | `bundle_dir`        | Directory where the bundle should be unpacked   | `string` | `dist`     |    no    |
+| `inject_config_cmd` | Command to run to inject the environment config | `string` | n/a        |    no    |
+| `post_upload_cmd`   | Command to run after files were uploaded to S3  | `string` | n/a        |    no    |
 | `registry_scope`    | Org scope for the GitHub Package Registry       | `string` | `@pleo-io` |    no    |
 
 #### Secrets

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -36,8 +36,8 @@ uploads the result to an S3 registry bucket.
 | ---------------- | ------------------------------------------------- | -------- | ---------- | :------: |
 | `app_name`       | Name of the app, unique for the repo, kebab-cased | `string` | n/a        |   yes    |
 | `bucket_name`    | Name of the S3 registry bucket                    | `string` | n/a        |   yes    |
-| `build_dir`      | Location of the deploy bundle after build         | `string` | n/a        |   yes    |
 | `build_cmd`      | Command for building the deploy bundle            | `string` | n/a        |   yes    |
+| `build_dir`      | Location of the deploy bundle after build         | `string` | n/a        |   yes    |
 | `registry_scope` | Org scope for the GitHub Package Registry         | `string` | `@pleo-io` |    no    |
 
 #### Secrets
@@ -81,11 +81,11 @@ the cursor file for the current branch.
 
 | Name                | Description                                     | Type     | Default    | Required |
 | ------------------- | ----------------------------------------------- | -------- | ---------- | :------: |
-| `environment`       | Name of the deployment environment              | `string` | n/a        |   yes    |
-| `bundle_uri`        | S3 URI of the bundle in the registry bucket     | `string` | n/a        |   yes    |
-| `tree_hash`         | Tree hash of the code to deploy                 | `string` | n/a        |   yes    |
 | `bucket_name`       | Name of the S3 origin bucket                    | `string` | n/a        |   yes    |
+| `bundle_uri`        | S3 URI of the bundle in the registry bucket     | `string` | n/a        |   yes    |
 | `domain_name`       | Domain name for the app (e.g. app.example.com)  | `string` | n/a        |   yes    |
+| `environment`       | Name of the deployment environment              | `string` | n/a        |   yes    |
+| `tree_hash`         | Tree hash of the code to deploy                 | `string` | n/a        |   yes    |
 | `bundle_dir`        | Directory where the bundle should be unpacked   | `string` | `dist`     |    no    |
 | `inject_config_cmd` | Command to run to inject the environment config | `string` | n/a        |    no    |
 | `post_upload_cmd`   | Command to run after files were uploaded to S3  | `string` | n/a        |    no    |

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -124,6 +124,10 @@ jobs:
            --recursive \
            --exclude "static/*"
 
+      - name: Post Upload Hook
+        if: inputs.post_upload_cmd
+        run: ${{inputs.post_upload_cmd }}
+
       - name: Update Cursor File
         id: cursor-update
         uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v8.0.2

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -38,6 +38,10 @@ on:
         required: false
         description: "Command to run to inject the environment config"
         type: string
+      post_upload_cmd:
+        required: false
+        description: "Command to run after files were uploaded to S3"
+        type: string
       registry_scope:
         required: false
         default: "@pleo-io"

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -38,10 +38,6 @@ on:
         required: false
         description: "Command to run to inject the environment config"
         type: string
-      post_upload_cmd:
-        required: false
-        description: "Command to run after files were uploaded to S3"
-        type: string
       registry_scope:
         required: false
         default: "@pleo-io"
@@ -124,9 +120,14 @@ jobs:
            --recursive \
            --exclude "static/*"
 
-      - name: Post Upload Hook
-        if: inputs.post_upload_cmd
-        run: ${{inputs.post_upload_cmd }}
+      - name: Update .well-known Files If Exists
+        run: |
+           aws s3 cp \
+            s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
+            s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
+            --content-type 'application/json' \
+            --cache-control 'public,max-age=3600' \
+            --metadata-directive REPLACE || echo "Failed updating .well-known files"
 
       - name: Update Cursor File
         id: cursor-update


### PR DESCRIPTION
Adds support for updating the cache control and content type of .well-known/apple-app-site-association files if exists.

Originally I wanted to add an optional `post_upload_cmd` to the SPA deployment. Use case is to update the content type of uploaded files. But turns out this needs to know a bunch of internals from spa-tools, like where we store static files and how we use the SHA to define the namespace...