### PR TITLE
fix: Don't set ACLs on newly created S3 bucket

### DIFF
--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -11,7 +11,7 @@ resource "local_file" "lambda_config" {
   content = jsonencode({
     "originBucketName"         = var.bucket_name
     "originBucketRegion"       = var.bucket_region
-    "previewDeploymentPostfix" = var.env == "staging" ? ".${var.domain_name}" : ""
+    "previewDeploymentPostfix"  = var.env == "production" ? "" : ".${var.domain_name}"
     "isLocalised"              = var.is_localised == true ? "true" : "false"
     "defaultBranchName"        = var.default_repo_branch_name
   })

--- a/terraform-module/modules/frontend-spa-s3/main.tf
+++ b/terraform-module/modules/frontend-spa-s3/main.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "origin" {
 
 resource "aws_s3_bucket_acl" "origin" {
   bucket = aws_s3_bucket.origin.id
-  acl    = "private"
+  acl    = null
 }
 
 resource "aws_s3_bucket_public_access_block" "origin" {


### PR DESCRIPTION
Attempt to fix deployment error when creating new s3 bucket in product-dev

```
Error: error creating S3 bucket ACL for pleo-product-web-origin-product-dev: AccessControlListNotSupported: The bucket does not allow ACLs
│ 	status code: 400, request id: 56KZSHVZQ7TT3DCV, host id: XxHiMf5u1F4ReafohWUBkgadVMXYnSf6Toq/1tcjrz12mXJcZ4+npTSbpiFOgogyiDTxVS/FhRU=
│ 
│   with module.app.module.s3.aws_s3_bucket_acl.origin,
│   on .terraform/modules/app/terraform-module/modules/frontend-spa-s3/main.tf line 20, in resource "aws_s3_bucket_acl" "origin":
│   20: resource "aws_s3_bucket_acl" "origin" {
```
The fix is based on [this Github comment](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/223#issuecomment-1516822132).
> If you're setting ACL to be 'private', you can probably workaround this issue by setting the ACL property to 'null' instead.

Apparently since April 2023 Amazon [disables ACLs](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) for newly created buckets by default.

I guess there's no way I can validate this fixes the issue unless I merge the thing or do some magic with feature branch deployments, which I'd rather avoid doing.