### PR TITLE
fix: S3 bucket creation

### DIFF
--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -11,7 +11,7 @@ resource "local_file" "lambda_config" {
   content = jsonencode({
     "originBucketName"         = var.bucket_name
     "originBucketRegion"       = var.bucket_region
-    "previewDeploymentPostfix"  = var.env == "production" ? "" : ".${var.domain_name}"
+    "previewDeploymentPostfix" = var.env == "production" ? "" : ".${var.domain_name}"
     "isLocalised"              = var.is_localised == true ? "true" : "false"
     "defaultBranchName"        = var.default_repo_branch_name
   })

--- a/terraform-module/modules/frontend-spa-s3/main.tf
+++ b/terraform-module/modules/frontend-spa-s3/main.tf
@@ -17,11 +17,6 @@ resource "aws_s3_bucket" "origin" {
   }
 }
 
-resource "aws_s3_bucket_acl" "origin" {
-  bucket = aws_s3_bucket.origin.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_ownership_controls" "origin" {
   bucket = aws_s3_bucket.origin.id
 

--- a/terraform-module/modules/frontend-spa-s3/main.tf
+++ b/terraform-module/modules/frontend-spa-s3/main.tf
@@ -19,7 +19,15 @@ resource "aws_s3_bucket" "origin" {
 
 resource "aws_s3_bucket_acl" "origin" {
   bucket = aws_s3_bucket.origin.id
-  acl    = null
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_ownership_controls" "origin" {
+  bucket = aws_s3_bucket.origin.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "origin" {


### PR DESCRIPTION
Follow up to https://github.com/pleo-io/spa-tools/pull/120

The original fix wasn't enough and resulted in a different error
> Error: error creating S3 bucket ACL for pleo-product-web-origin-product-dev: MissingSecurityHeader: Your request was missing a required header

After discussion with Radek we can either refactor the s3 terraform config to use the [preconfigured s3 module](https://github.com/pleo-io/terraform-modules/blob/2f947ef1b5d2f292971d35d84e1b9c1bb4197212/flux-config/feature-deployment.tf#L2) as is used in our terraform-modules.

I didn't want to get into bigger refactors as I still don't understand properly how things work, so I chose to adjust the current config to hopefully fix the error. This fix is based on [this github comment](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/223#issuecomment-1549827077)

I've already validated locally that the changes from that PR work on both product-dev and staging - even after removing the ACL resource I'm able to deploy the app to staging ([job here](https://github.com/pleo-io/product-web/actions/runs/6025800666/job/16347516978?pr=12380)) and I was also able to deploy to product-dev - don't have a link to the job anymore but I do have the deployed app under [this URL](https://preview-8d97feb2c3462174e47f694dca3dd38f19b464b3.app.dev.pleo.io/login).