### PR TITLE
feat: add environment suffix to github artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Upload Deployed Bundle as Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: bundle-${{ inputs.tree_hash }}
+          name: bundle-${{ inputs.tree_hash }}-{{ inputs.environment }}
           path: bundle.tar.gz
 
       - name: Verify app deployment

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Upload Deployed Bundle as Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: bundle-${{ inputs.tree_hash }}
+          name: bundle-${{ inputs.tree_hash }}-{{ inputs.environment }}
           path: bundle.tar.gz
 
       - name: Verify app deployment


### PR DESCRIPTION
currently we're only using the tree_hash as name of our artifact, but tree_hash is the same across all environments. So we're overwriting existing artifacts and only have a single one for production in the end. 
After this change we should have an artifact per environment.

I'm hopeful that this will also fix the errors we're seeing since introducing the product-dev environment, my assumption is that github locks the artifact for a short time during upload and when the stars align product-dev and staging upload at the same time, creating this error.

to my best knowledge we're not using these artifacts programatically & we only upload the artifact for reference, so this should be safe to rename.

<img width="1587" alt="Screenshot 2023-09-14 at 13 15 22" src="https://github.com/pleo-io/spa-tools/assets/1761818/78f574e3-dade-4779-812b-a916bdd0ea76">


