### PR TITLE
fix: add missing $ to artifact name template

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Upload Deployed Bundle as Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: bundle-${{ inputs.tree_hash }}-{{ inputs.environment }}
+          name: bundle-${{ inputs.tree_hash }}-${{ inputs.environment }}
           path: bundle.tar.gz
 
       - name: Verify app deployment

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Upload Deployed Bundle as Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: bundle-${{ inputs.tree_hash }}-{{ inputs.environment }}
+          name: bundle-${{ inputs.tree_hash }}-${{ inputs.environment }}
           path: bundle.tar.gz
 
       - name: Verify app deployment


### PR DESCRIPTION
i forgot a dollar-sign in the bundle name template when uploading the github artifact, resulting in an artifact-name like `[bundle-84eb00d28e6c45b60f9ca7780cdec54c9992a696-{{ inputs.environment }}](https://github.com/pleo-io/product-web/suites/16174949115/artifacts/923652064)` (https://github.com/pleo-io/product-web/actions/runs/6188302609)

this change should fix it so we get `bundle-84eb00d28e6c45b60f9ca7780cdec54c9992a696-staging` and so on