### PR TITLE
feat: add variable to disable indexing

### DIFF
--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -79,8 +79,8 @@ No resources.
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
-| <a name="input_is_indexed"></a> [is\_indexed](#input\_is\_indexed) | Should allow search engine indexing in production? | `bool` | `true` | no |
 | <a name="input_is_localised"></a> [is\_localised](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `false` | no |
+| <a name="input_is_robots_indexing_allowed"></a> [is\_robots\_indexing\_allowed](#input\_is\_robots\_indexing\_allowed) | Should allow search engine indexing in production? | `bool` | `true` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com) | `string` | n/a | yes |
 | <a name="input_zone_domain"></a> [zone\_domain](#input\_zone\_domain) | The domain where the app lives (e.g. 'example.com' if the app lives at hello.example.com) | `string` | n/a | yes |
 

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -79,6 +79,7 @@ No resources.
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
+| <a name="input_is_indexed"></a> [is\_indexed](#input\_is\_indexed) | Should allow search engine indexing in production? | `bool` | `true` | no |
 | <a name="input_is_localised"></a> [is\_localised](#input\_is\_localised) | Should fetch translation hash and add cookie & preload header for translation files? | `bool` | `false` | no |
 | <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com) | `string` | n/a | yes |
 | <a name="input_zone_domain"></a> [zone\_domain](#input\_zone\_domain) | The domain where the app lives (e.g. 'example.com' if the app lives at hello.example.com) | `string` | n/a | yes |

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -53,8 +53,8 @@ module "cdn" {
   domain_name   = local.domain_name
   bucket_name   = module.s3.bucket_name
   block_iframes = var.block_iframes
-  is_indexed    = var.is_indexed
 
+  is_robots_indexing_allowed      = var.is_robots_indexing_allowed
   bucket_regional_domain_name     = module.s3.bucket_regional_domain_name
   cloudfront_access_identity_path = module.s3.cloudfront_access_identity_path
   edge_lambdas = [

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -53,6 +53,7 @@ module "cdn" {
   domain_name   = local.domain_name
   bucket_name   = module.s3.bucket_name
   block_iframes = var.block_iframes
+  is_indexed    = var.is_indexed
 
   bucket_regional_domain_name     = module.s3.bucket_regional_domain_name
   cloudfront_access_identity_path = module.s3.cloudfront_access_identity_path

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
     items {
       header   = "X-Robots-Tag"
       override = true
-      value    = var.is_indexed && var.env == "production" ? "all" : "noindex, nofollow"
+      value    = var.is_robots_indexing_allowed && var.env == "production" ? "all" : "noindex, nofollow"
     }
   }
 }

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
     items {
       header   = "X-Robots-Tag"
       override = true
-      value    = var.env == "production" ? "all" : "noindex, nofollow"
+      value    = var.is_indexed && var.env == "production" ? "all" : "noindex, nofollow"
     }
   }
 }

--- a/terraform-module/modules/frontend-spa-cdn/vars.tf
+++ b/terraform-module/modules/frontend-spa-cdn/vars.tf
@@ -53,7 +53,7 @@ variable "block_iframes" {
   type        = bool
 }
 
-variable "is_indexed" {
+variable "is_robots_indexing_allowed" {
   description = "Should allow search engine indexing in production?"
   default     = true
   type        = bool

--- a/terraform-module/modules/frontend-spa-cdn/vars.tf
+++ b/terraform-module/modules/frontend-spa-cdn/vars.tf
@@ -52,3 +52,9 @@ variable "block_iframes" {
   default     = true
   type        = bool
 }
+
+variable "is_indexed" {
+  description = "Should allow search engine indexing in production?"
+  default     = true
+  type        = bool
+}

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -41,7 +41,7 @@ variable "default_repo_branch_name" {
   type        = string
 }
 
-variable "is_indexed" {
+variable "is_robots_indexing_allowed" {
   description = "Should allow search engine indexing in production?"
   default     = true
   type        = bool

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -40,3 +40,9 @@ variable "default_repo_branch_name" {
   default     = "master"
   type        = string
 }
+
+variable "is_indexed" {
+  description = "Should allow search engine indexing in production?"
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
currently our robots directive always allows indexing in production, for our purposes we don't want the app indexed though.
this PR adds an option to allow indexing, to avoid a breaking change i'm making this `true` by default. 