### PR TITLE
feat!: Update spa-tools build workflow to provide Datadog API key as env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ on:
         type: string
       build_dir:
         required: true
-        description:
-          "Location of the deploy bundle after running the build command"
+        description: "Location of the deploy bundle after running the build command"
         type: string
       build_cmd:
         required: true
@@ -56,8 +55,7 @@ jobs:
           bucket-name: ${{ inputs.bucket_name }}
           key-prefix: build/${{ inputs.app_name }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
-          aws-secret-access-key:
-            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - uses: pnpm/action-setup@v2
@@ -82,6 +80,8 @@ jobs:
       - name: Build
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
+        env:
+          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY }}
 
       - name: Get Bundle S3 URI
         id: bundle-uri
@@ -91,8 +91,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
-          aws-secret-access-key:
-            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - name: Compress & Upload Bundle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
         env:
-          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY }}
+          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY || null }}
 
       - name: Get Bundle S3 URI
         id: bundle-uri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,8 @@ jobs:
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
         env:
-          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY || null }}
+          DD_TRACK_BUNDLE: ${{ github.ref == 'refs/heads/main' && true || false }}
+          DD_API_KEY: secrets.DD_API_KEY
 
       - name: Get Bundle S3 URI
         id: bundle-uri

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -46,12 +46,12 @@ Use the
 [`secrets: inherit`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit)
 options when using the workflow.
 
-| Name                                      | Description                                                       | Required |
-| ----------------------------------------- | ----------------------------------------------------------------- | :------: |
-| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket     |   yes    |
-| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket |   yes    |
-| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                    |   yes    |
-| `DD_API_KEY`                              | API key for Datadog                                               |   yes    |
+| Name                                      | Description                                                                         | Required |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- | :------: |
+| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket                       |   yes    |
+| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket                   |   yes    |
+| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                                      |   yes    |
+| `DD_API_KEY`                              | API key for Datadog, used to send the Datadog Bundle Plugin's `entries.size` metric |   yes    |
 
 #### Outputs
 

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -51,6 +51,7 @@ options when using the workflow.
 | `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket     |   yes    |
 | `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket |   yes    |
 | `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                    |   yes    |
+| `DD_API_KEY`                              | API key for Datadog                                               |   yes    |
 
 #### Outputs
 

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -46,12 +46,13 @@ Use the
 [`secrets: inherit`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit)
 options when using the workflow.
 
-| Name                                      | Description                                                                         | Required |
-| ----------------------------------------- | ----------------------------------------------------------------------------------- | :------: |
-| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket                       |   yes    |
-| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket                   |   yes    |
-| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                                      |   yes    |
-| `DD_API_KEY`                              | API key for Datadog, used to send the Datadog Bundle Plugin's `entries.size` metric |   yes    |
+| Name                                      | Description                                                                                | Required |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------ | :------: |
+| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket                              |   yes    |
+| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket                          |   yes    |
+| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                                             |   yes    |
+| `DD_TRACK_BUNDLE`                         | When true Datadog's Build Plugin is called and attempts to track the `entries.size` metric |    no    |
+| `DD_API_KEY`                              | API key for Datadog, used with Datadog's Build Plugin as mentioned above                   |    no    |
 
 #### Outputs
 

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -15,8 +15,7 @@ on:
         type: string
       build_dir:
         required: true
-        description:
-          "Location of the deploy bundle after running the build command"
+        description: "Location of the deploy bundle after running the build command"
         type: string
       build_cmd:
         required: true
@@ -56,8 +55,7 @@ jobs:
           bucket-name: ${{ inputs.bucket_name }}
           key-prefix: build/${{ inputs.app_name }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
-          aws-secret-access-key:
-            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - uses: pnpm/action-setup@v2
@@ -82,6 +80,8 @@ jobs:
       - name: Build
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
+        env:
+          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY }}
 
       - name: Get Bundle S3 URI
         id: bundle-uri
@@ -91,8 +91,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
-          aws-secret-access-key:
-            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - name: Compress & Upload Bundle

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
         env:
-          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY }}
+          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY || null }}
 
       - name: Get Bundle S3 URI
         id: bundle-uri

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -81,7 +81,8 @@ jobs:
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
         env:
-          DD_API_KEY: ${{ github.ref == 'refs/heads/main' && secrets.DD_API_KEY || null }}
+          DD_TRACK_BUNDLE: ${{ github.ref == 'refs/heads/main' && true || false }}
+          DD_API_KEY: secrets.DD_API_KEY
 
       - name: Get Bundle S3 URI
         id: bundle-uri


### PR DESCRIPTION
Update spa-tools build workflow so that it provides and API key when ran on the main branch to be used by https://github.com/pleo-io/bff-tools/pull/263 