### PR TITLE
chore!: Remove now redundant env variables in spa-tools build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,9 +80,6 @@ jobs:
       - name: Build
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
-        env:
-          DD_TRACK_BUNDLE: ${{ github.ref == 'refs/heads/main' && true || false }}
-          DD_API_KEY: secrets.DD_API_KEY
 
       - name: Get Bundle S3 URI
         id: bundle-uri

--- a/reusable-workflows/README.md
+++ b/reusable-workflows/README.md
@@ -46,13 +46,11 @@ Use the
 [`secrets: inherit`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit)
 options when using the workflow.
 
-| Name                                      | Description                                                                                | Required |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------ | :------: |
-| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket                              |   yes    |
-| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket                          |   yes    |
-| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                                             |   yes    |
-| `DD_TRACK_BUNDLE`                         | When true Datadog's Build Plugin is called and attempts to track the `entries.size` metric |    no    |
-| `DD_API_KEY`                              | API key for Datadog, used with Datadog's Build Plugin as mentioned above                   |    no    |
+| Name                                      | Description                                                       | Required |
+| ----------------------------------------- | ----------------------------------------------------------------- | :------: |
+| `AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY`     | ID of a AWS key that allows r/w access to the registry bucket     |   yes    |
+| `AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY` | Secret of a AWS key that allows r/w access to the registry bucket |   yes    |
+| `GH_REGISTRY_NPM_TOKEN`                   | Token for NPM package registry                                    |   yes    |
 
 #### Outputs
 

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -80,9 +80,6 @@ jobs:
       - name: Build
         if: steps.s3-cache.outputs.processed == 'false'
         run: ${{ inputs.build_cmd }}
-        env:
-          DD_TRACK_BUNDLE: ${{ github.ref == 'refs/heads/main' && true || false }}
-          DD_API_KEY: secrets.DD_API_KEY
 
       - name: Get Bundle S3 URI
         id: bundle-uri


### PR DESCRIPTION
These are now redundant due to https://github.com/pleo-io/bff-tools/pull/270