### PR TITLE
fix(deps) Upgrade vite due to vulnerability

### DIFF
--- a/config-inject/package.json
+++ b/config-inject/package.json
@@ -46,7 +46,7 @@
         "zod": "^3.21.4"
     },
     "peerDependencies": {
-        "vite": "^4.3.9"
+        "vite": "^4.5.1"
     },
     "devDependencies": {
         "@swc/core": "1.3.96",
@@ -60,7 +60,7 @@
         "prettier": "2.8.8",
         "tsup": "^6.7.0",
         "typescript": "5.2.2",
-        "vite": "^4.3.9"
+        "vite": "^4.5.1"
     },
     "prettier": {
         "printWidth": 100,


### PR DESCRIPTION
[HELA-2218 Vite XSS vulnerability in `server.transformIndexHtml` via URL payload spa-tools](https://linear.app/pleo/issue/HELA-2218/vite-xss-vulnerability-in-servertransformindexhtml-via-url-payload-spa)

Vulnerability in backoffice on a version before 4.5.0: https://github.com/pleo-io/backoffice/security/dependabot/74