### PR TITLE
fix: links breaking due to img tag

### DIFF
--- a/actions/post-preview-urls/dist/main/index.js
+++ b/actions/post-preview-urls/dist/main/index.js
@@ -9655,6 +9655,9 @@ async function postPreviewUrls({
   const isFreshPR = !(prDescription == null ? void 0 : prDescription.includes(markerStart));
   const prDescriptionAbove = ((_a = prDescription == null ? void 0 : prDescription.split(markerStart)[0]) == null ? void 0 : _a.trim()) ?? "";
   const prDescriptionBelow = ((_b = prDescription == null ? void 0 : prDescription.split(markerEnd).pop()) == null ? void 0 : _b.trim()) ?? "";
+  const anyMarkerStart = new RegExp(`<!--.+-preview-urls-do-not-change-below-->`);
+  const prDescriptionAboveIncludesOtherApp = !!prDescriptionAbove.match(anyMarkerStart);
+  const descriptionAppendage = prDescriptionAboveIncludesOtherApp ? "" : "\n";
   const linksMessages = links.map((link) => {
     if (asLabels) {
       return `[${link.name}](${link.url})`;
@@ -9663,7 +9666,7 @@ async function postPreviewUrls({
   }).join(asLabels ? ", " : "\n");
   const heading = `**${appName} preview links**`;
   const body = [
-    prDescriptionAbove,
+    prDescriptionAbove + descriptionAppendage,
     markerStart,
     "---",
     heading,

--- a/actions/post-preview-urls/index.test.ts
+++ b/actions/post-preview-urls/index.test.ts
@@ -39,6 +39,7 @@ describe(`Post Preview URLs action`, () => {
                     body: strip`
                     Hello World!
                      Some indent
+
                     <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
@@ -89,6 +90,7 @@ describe(`Post Preview URLs action`, () => {
                     body: strip`
                     Hello World!
                      Some indent
+
                     <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
@@ -115,6 +117,7 @@ describe(`Post Preview URLs action`, () => {
                     body: strip`
                         Hello World!
                          Some indent
+
                         <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
@@ -142,6 +145,7 @@ describe(`Post Preview URLs action`, () => {
                     body: strip`
                     Hello World!
                      Some indent
+
                     <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
@@ -197,6 +201,7 @@ describe(`Post Preview URLs action`, () => {
                 {
                     body: strip`
                     Hello World!
+
                     <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
@@ -224,6 +229,7 @@ describe(`Post Preview URLs action`, () => {
                 data: {
                     body: strip`
                         Hello World!
+
                         <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
@@ -256,6 +262,7 @@ describe(`Post Preview URLs action`, () => {
                 {
                     body: strip`
                         Hello World!
+
                         <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
@@ -290,6 +297,7 @@ describe(`Post Preview URLs action`, () => {
                 data: {
                     body: strip`
                     Hello World!
+
                     <!--storybook-preview-urls-do-not-change-below-->
                     ---
                     **🤖 Storybook preview links**
@@ -326,6 +334,7 @@ describe(`Post Preview URLs action`, () => {
             expect(mockRequest).toBeCalledWith('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
                 body: strip`
                 Hello World!
+
                 <!--storybook-preview-urls-do-not-change-below-->
                 ---
                 **📚 Storybook preview links**
@@ -343,6 +352,51 @@ describe(`Post Preview URLs action`, () => {
                 pull_number: 1,
                 repo: 'my-repo'
             })
+        }
+    )
+
+    test(
+        strip`
+        When there is no newline after PR description
+        It adds one before the preview links
+        And keeps the description and links in tact
+        `,
+        async () => {
+            const token = '1234'
+            const mockRequest = jest.fn().mockResolvedValueOnce({
+                data: {body: 'Hello World!\n Some indent'}
+            })
+            mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
+
+            await postPreviewUrls({
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature.app.example.com'}
+                ]),
+                token,
+                repo: {owner: 'my-org', repo: 'my-repo'},
+                prNumber: 1,
+                appName: '🤖 App'
+            })
+
+            expect(mockedGithub.getOctokit).toBeCalledWith(token)
+            expect(mockRequest).toHaveBeenLastCalledWith(
+                'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                    body: strip`
+                    Hello World!
+                     Some indent
+
+                    <!--app-preview-urls-do-not-change-below-->
+                    ---
+                    **🤖 App preview links**
+                    _Latest_: https://feature.app.example.com
+                    <!--app-preview-urls-do-not-change-above-->
+                `,
+                    owner: 'my-org',
+                    pull_number: 1,
+                    repo: 'my-repo'
+                }
+            )
         }
     )
 })

--- a/actions/post-preview-urls/index.ts
+++ b/actions/post-preview-urls/index.ts
@@ -51,6 +51,10 @@ export async function postPreviewUrls({
     const prDescriptionAbove = prDescription?.split(markerStart)[0]?.trim() ?? ''
     const prDescriptionBelow = prDescription?.split(markerEnd).pop()?.trim() ?? ''
 
+    const anyMarkerStart = new RegExp(`<!--.+-preview-urls-do-not-change-below-->`)
+    const prDescriptionAboveIncludesOtherApp = !!prDescriptionAbove.match(anyMarkerStart)
+    const descriptionAppendage = prDescriptionAboveIncludesOtherApp ? '' : '\n'
+
     const linksMessages = links
         .map((link) => {
             if (asLabels) {
@@ -62,7 +66,7 @@ export async function postPreviewUrls({
     const heading = `**${appName} preview links**`
 
     const body = [
-        prDescriptionAbove,
+        prDescriptionAbove + descriptionAppendage,
         markerStart,
         '---',
         heading,


### PR DESCRIPTION
This PR attempts to fix the issue where an image tag (<img…) at the end of the PR description breaks the markdown formatting, for example:

<kbd><img width="845" alt="Screenshot 2024-03-26 at 14 03 13" src="https://github.com/pleo-io/spa-tools/assets/4415071/72dbb73a-44fb-4e78-a920-72316022e092"></kbd>



The proposed fix will add a newline after the PR description when posting the top-most app links, such as the BFF preview links in `product-web`.