### PR TITLE
fix(deps): udpate actions/checkout to trigger a new release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       tree_hash: ${{ steps.s3-cache.outputs.hash }}
       bundle_uri: ${{ steps.bundle-uri.outputs.uri }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1.6
 
       - name: Check S3 Cache
         uses: pleo-io/s3-cache-action@v3.0.0

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       tree_hash: ${{ steps.s3-cache.outputs.hash }}
       bundle_uri: ${{ steps.bundle-uri.outputs.uri }}
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4.1.6
 
       - name: Check S3 Cache
         uses: pleo-io/s3-cache-action@v3.0.0


### PR DESCRIPTION
updates actions/checkout from 4.1.4 to 4.1.6,
this will trigger a new release of spa-tools/reusable-workflows version 11.0.1, so that we can update github actions to node 20 in product-web.