### PR TITLE
fix(deps): update spa-github-actions to latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,12 +130,12 @@ jobs:
 
       - name: Update Cursor File
         id: cursor-update
-        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v8.3.0
+        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v9.0.2
         with:
           bucket_name: ${{ inputs.bucket_name }}
 
       - name: Update PR Description
-        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v8.3.0
+        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v9.0.2
         if: github.event_name == 'pull_request'
         with:
           app_name: ${{ inputs.app_name }}

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -130,12 +130,12 @@ jobs:
 
       - name: Update Cursor File
         id: cursor-update
-        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v8.3.0
+        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v9.0.2
         with:
           bucket_name: ${{ inputs.bucket_name }}
 
       - name: Update PR Description
-        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v8.3.0
+        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v9.0.2
         if: github.event_name == 'pull_request'
         with:
           app_name: ${{ inputs.app_name }}


### PR DESCRIPTION
we have updated the actions cursor-deploy and post-preview-urls to node 20 already, but forgot to update the versions of those actions where they are used inside spa-tools itself. Fixed in this PR.