### PR TITLE
feat: Cache node_modules/.pnpm instead of the global store

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,15 @@ jobs:
           node-version: "20"
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
-          cache: "pnpm"
+
+      - name: Cache node_modules/.pnpm
+        if: steps.s3-cache.outputs.processed == 'false'
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules/.pnpm
+          key: pnpm-node-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-node-modules-
 
       - name: Install Dependencies
         if: steps.s3-cache.outputs.processed == 'false'

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -73,7 +73,15 @@ jobs:
           node-version: "20"
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
-          cache: "pnpm"
+
+      - name: Cache node_modules/.pnpm
+        if: steps.s3-cache.outputs.processed == 'false'
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules/.pnpm
+          key: pnpm-node-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-node-modules-
 
       - name: Install Dependencies
         if: steps.s3-cache.outputs.processed == 'false'


### PR DESCRIPTION
Related to https://github.com/pleo-io/product-web/pull/15858 I'd like to test caching dependencies differently to improve `pnpm install` speed.