### PR TITLE
chore: update pnpm/action-setup to v4.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         if: steps.s3-cache.outputs.processed == 'false'
         with:
           version: ${{ inputs.pnpm_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4.1.4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 9
       - uses: actions/setup-node@v4.0.2
@@ -79,7 +79,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4.1.4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 9
       - uses: actions/setup-node@v4.0.2
@@ -106,7 +106,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4.1.4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 9
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: config-inject
     steps:
       - uses: actions/checkout@v4.1.4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 9
       - uses: actions/setup-node@v4.0.2

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         if: steps.s3-cache.outputs.processed == 'false'
         with:
           version: ${{ inputs.pnpm_version }}


### PR DESCRIPTION
Update `pnpm/action-setup` to `v4.0.0`
  -  Also, notice we now used the "full" version `v4.0.0`, instead of `v4`, that way Renovate will be able to propose future updates. See related known issue: https://github.com/pnpm/action-setup/issues/95