### PR TITLE
feat: Move github-deployment-env to spa terraform-modules

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,5 @@
   "actions": "9.0.2",
   "reusable-workflows": "11.3.0",
   "config-inject": "3.1.1",
-  "terraform-module": "3.1.1"
+  "terraform-module": "3.2.1"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,5 @@
   "actions": "9.0.2",
   "reusable-workflows": "11.3.0",
   "config-inject": "3.1.1",
-  "terraform-module": "3.2.1"
+  "terraform-module": "3.1.1"
 }

--- a/terraform-module/modules/frontend-github-deployment-env/README.md
+++ b/terraform-module/modules/frontend-github-deployment-env/README.md
@@ -1,0 +1,61 @@
+# GitHub Deployment Environment
+
+Creates a GitHub deployment environment, and injects provided AWS credentials
+into that new environment's secrets. See GitHub documentation on
+[GitHub deployment environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment).
+
+## How to use
+
+```hcl
+module "deployment_env" {
+  source = "api.env0.com/ed3d7d49-aa1a-4456-8ccb-3b56dd0e7070/github-deployment-env/aws"
+  version = "1.0.0"
+
+  repo_name          = "my-repo"
+  env_name           = "staging"
+  access_key_id      = aws_iam_access_key.key.id
+  access_key_secret  = aws_iam_access_key.key.secret
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [github_actions_environment_secret.access_key_id](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
+| [github_actions_environment_secret.secret_access_key](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret) | resource |
+| [github_repository_environment.this](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_key_id"></a> [access\_key\_id](#input\_access\_key\_id) | AWS access key ID | `string` | n/a | yes |
+| <a name="input_access_key_secret"></a> [access\_key\_secret](#input\_access\_key\_secret) | AWS secret access key | `string` | n/a | yes |
+| <a name="input_env_name"></a> [env\_name](#input\_env\_name) | Name of the environment | `string` | n/a | yes |
+| <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | Name of the repository to create the environment | `string` | n/a | yes |
+| <a name="input_protected_branches"></a> [protected\_branches](#input\_protected\_branches) | Whether only branches with branch protection rules can deploy to this environment. | `bool` | `false` | no |
+| <a name="input_reviewer_teams"></a> [reviewer\_teams](#input\_reviewer\_teams) | List of up to 6 IDs of teams required to review a deployment to the environment | `list(string)` | `[]` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform-module/modules/frontend-github-deployment-env/README.md
+++ b/terraform-module/modules/frontend-github-deployment-env/README.md
@@ -8,8 +8,7 @@ into that new environment's secrets. See GitHub documentation on
 
 ```hcl
 module "deployment_env" {
-  source = "api.env0.com/ed3d7d49-aa1a-4456-8ccb-3b56dd0e7070/github-deployment-env/aws"
-  version = "1.0.0"
+  source = "git@github.com:pleo-io/spa-tools.git//terraform-module/modules/frontend-github-deployment-env?ref=terraform-module-v3.1.1"
 
   repo_name          = "my-repo"
   env_name           = "staging"

--- a/terraform-module/modules/frontend-github-deployment-env/main.tf
+++ b/terraform-module/modules/frontend-github-deployment-env/main.tf
@@ -1,0 +1,29 @@
+resource "github_repository_environment" "this" {
+  repository  = var.repo_name
+  environment = var.env_name
+  reviewers {
+    teams = var.reviewer_teams
+  }
+
+  dynamic "deployment_branch_policy" {
+    for_each = var.protected_branches == false ? [] : [1]
+    content {
+      protected_branches     = true
+      custom_branch_policies = false
+    }
+  }
+}
+
+resource "github_actions_environment_secret" "access_key_id" {
+  repository      = var.repo_name
+  environment     = github_repository_environment.this.environment
+  secret_name     = "AWS_ACCESS_KEY_ID"
+  plaintext_value = var.access_key_id
+}
+
+resource "github_actions_environment_secret" "secret_access_key" {
+  repository      = var.repo_name
+  environment     = github_repository_environment.this.environment
+  secret_name     = "AWS_SECRET_ACCESS_KEY"
+  plaintext_value = var.access_key_secret
+}

--- a/terraform-module/modules/frontend-github-deployment-env/variables.tf
+++ b/terraform-module/modules/frontend-github-deployment-env/variables.tf
@@ -1,0 +1,31 @@
+variable "repo_name" {
+  description = "Name of the repository to create the environment"
+  type        = string
+}
+
+variable "env_name" {
+  description = "Name of the environment"
+  type        = string
+}
+
+variable "access_key_id" {
+  description = "AWS access key ID"
+  type        = string
+}
+
+variable "access_key_secret" {
+  description = "AWS secret access key"
+  type        = string
+}
+
+variable "protected_branches" {
+  description = "Whether only branches with branch protection rules can deploy to this environment."
+  type        = bool
+  default     = false
+}
+
+variable "reviewer_teams" {
+  description = "List of up to 6 IDs of teams required to review a deployment to the environment"
+  type        = list(string)
+  default     = []
+}

--- a/terraform-module/modules/frontend-github-deployment-env/versions.tf
+++ b/terraform-module/modules/frontend-github-deployment-env/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Move github-deployment-env module from infrastructure-terraform-modules to spa-tools.

This action is related to a [linear ticket](https://linear.app/pleo/issue/SRE-5682/mark-modules-deprecated) in the SRE Backlog to cleanup our repositories from modules that are not being actively maintained or created by the SRE. 

