### PR TITLE
fix: Change default runner for build reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ on:
         default: "@pleo-io"
         description: "Org scope for the GitHub Package Registry"
         type: string
+      runner:
+        required: false
+        default: ubuntu-latest-8-cores
+        description: "Use a specific size of job runner to run this workflow"
+        type: string
       turbo_cache:
         required: false
         description: "Use Turborepo Remote Cache"
@@ -49,7 +54,7 @@ on:
 jobs:
   build:
     name: Build & Upload
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ inputs.runner }}
     outputs:
       tree_hash: ${{ steps.s3-cache.outputs.hash }}
       bundle_uri: ${{ steps.bundle-uri.outputs.uri }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,9 @@ on:
         description: "Command for building the deploy bundle"
         type: string
       pnpm_version:
-        required: true
-        description: "pnpm version to configure"
+        required: false
+        default: 0
+        description: "pnpm version to install. If ommitted, the project needs to have the version specified in the 'packageManager' field in its package.json"
         type: number
       registry_scope:
         required: false
@@ -74,7 +75,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         if: steps.s3-cache.outputs.processed == 'false'
         with:
-          version: ${{ inputs.pnpm_version }}
+          version: ${{ inputs.pnpm_version != 0 && inputs.pnpm_version || null }}
 
       - uses: actions/setup-node@v4.0.2
         if: steps.s3-cache.outputs.processed == 'false'

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -30,6 +30,11 @@ on:
         default: "@pleo-io"
         description: "Org scope for the GitHub Package Registry"
         type: string
+      runner:
+        required: false
+        default: ubuntu-latest-8-cores
+        description: "Use a specific size of job runner to run this workflow"
+        type: string
       turbo_cache:
         required: false
         description: "Use Turborepo Remote Cache"
@@ -49,7 +54,7 @@ on:
 jobs:
   build:
     name: Build & Upload
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ inputs.runner }}
     outputs:
       tree_hash: ${{ steps.s3-cache.outputs.hash }}
       bundle_uri: ${{ steps.bundle-uri.outputs.uri }}

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -22,8 +22,9 @@ on:
         description: "Command for building the deploy bundle"
         type: string
       pnpm_version:
-        required: true
-        description: "pnpm version to configure"
+        required: false
+        default: 0
+        description: "pnpm version to install. If ommitted, the project needs to have the version specified in the 'packageManager' field in its package.json"
         type: number
       registry_scope:
         required: false
@@ -74,7 +75,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         if: steps.s3-cache.outputs.processed == 'false'
         with:
-          version: ${{ inputs.pnpm_version }}
+          version: ${{ inputs.pnpm_version != 0 && inputs.pnpm_version || null }}
 
       - uses: actions/setup-node@v4.0.2
         if: steps.s3-cache.outputs.processed == 'false'


### PR DESCRIPTION
Some repositories don't have access to the 16 core runner so we're changing the default to 8 core, and adding a new `runner` parameter to specify a different runner.

Additional change is that now the reusable workflow is able to to read the correct `pnpm` version from package.json `packageManger` field. I had to make this change in order to test the runner change in product-web, otherwise I was seeing the following error
![image](https://github.com/user-attachments/assets/7a1ae5b3-8de6-4e2b-a816-b9712027bc42)