### PR TITLE
fix: Support turbo hash in preview deploy URLs

### DIFF
--- a/terraform-module/edge-lambdas/dist/viewer-response/index.js
+++ b/terraform-module/edge-lambdas/dist/viewer-response/index.js
@@ -70,10 +70,12 @@ function getConfig() {
  * @returns A new, modified CloudFront header maps
  */
 function setHeader(headers, headerName, headerValue, options = {}) {
-    var _a;
     const headerKey = headerName.toLowerCase();
-    const previousHeader = options.merge ? (_a = headers[headerKey]) !== null && _a !== void 0 ? _a : [] : [];
-    return Object.assign(Object.assign({}, headers), { [headerKey]: [...previousHeader, { key: headerName, value: headerValue }] });
+    const previousHeader = options.merge ? headers[headerKey] ?? [] : [];
+    return {
+        ...headers,
+        [headerKey]: [...previousHeader, { key: headerName, value: headerValue }]
+    };
 }
 /**
  * Retrieve a header value (first if multiple values set) for a passed CloudFront request
@@ -82,8 +84,7 @@ function setHeader(headers, headerName, headerValue, options = {}) {
  * @returns The first found value of the specified header, if available
  */
 function getHeader(request, headerName) {
-    var _a, _b, _c;
-    return (_c = (_b = (_a = request.headers) === null || _a === void 0 ? void 0 : _a[headerName.toLowerCase()]) === null || _b === void 0 ? void 0 : _b[0]) === null || _c === void 0 ? void 0 : _c.value;
+    return request.headers?.[headerName.toLowerCase()]?.[0]?.value;
 }
 /**
  * Extract the value of a specific cookie from CloudFront headers map, if present
@@ -110,15 +111,6 @@ function getCookie(headers, cookieName) {
 const APP_VERSION_HEADER = 'X-Pleo-SPA-Version';
 
 ;// CONCATENATED MODULE: ./src/viewer-response/viewer-response.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 
 /**
  * Edge Lambda handler triggered on "viewer-response" event, on the default CF behavior of the web app CF distribution.
@@ -130,12 +122,12 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
  * We're going via a getHandler method to aid testing with dependency injection
  */
 function getHandler(config) {
-    const handler = (event) => __awaiter(this, void 0, void 0, function* () {
+    const handler = async (event) => {
         let response = event.Records[0].cf.response;
         const request = event.Records[0].cf.request;
         response = addVersionHeader(response, request);
         return response;
-    });
+    };
     return handler;
 }
 // Add a custom version header to the response (used e.g. for checking for new SPA versions)
@@ -143,7 +135,7 @@ function getHandler(config) {
 function addVersionHeader(response, request) {
     const appVersion = getHeader(request, APP_VERSION_HEADER);
     let headers = setHeader(response.headers, APP_VERSION_HEADER, appVersion);
-    return Object.assign(Object.assign({}, response), { headers });
+    return { ...response, headers };
 }
 
 ;// CONCATENATED MODULE: ./src/viewer-response/index.ts

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -20,11 +20,11 @@ const DEFAULT_BRANCH_DEFAULT_NAME = 'master'
  * based on the host name specified by the request, and sets that file as the URI of the request.
  * The options are:
  * - HTML for latest app version on the main branch
- *   e.g. app.staging.example.com and app.example.com
+ *   e.g. app.dev.example.com and app.example.com
  * - HTML for latest app version on a feature branch (branch preview deployment)
- *   e.g. my-branch.staging.example.com
+ *   e.g. my-branch.dev.example.com
  * - HTML for a specific app version (hash preview deployment)
- *   e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.staging.example.com
+ *   e.g. preview-b104213fc39ecca4f237a7bd6544d428ad46ec7e.app.dev.example.com
  *
  * If the translations are enabled via configuration, this lambda will also fetch the current translation
  * version from S3 and pass it to the response lambda via custom headers on the request object.
@@ -83,7 +83,7 @@ function getUri(request: CloudFrontRequest, appVersion: string) {
 async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3Client) {
     const host = getHeader(request, 'host') ?? null
 
-    // Preview name is the first segment of the url e.g. my-branch for my-branch.app.staging.example.com
+    // Preview name is the first segment of the url e.g. my-branch for my-branch.app.dev.example.com
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName: string
 
@@ -105,7 +105,7 @@ async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3C
 }
 
 /**
- * We serve a preview for each app version at e.g.preview-[hash].app.staging.example.com
+ * We serve a preview for each app version at e.g.preview-[hash].app.dev.example.com
  * If the preview name matches that pattern, we assume it's a hash preview link
  */
 function getPreviewHash(previewName?: string) {

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -34,9 +34,6 @@ export function getHandler(config: Config, s3: S3Client) {
         const request = event.Records[0].cf.request
 
         try {
-            // Get app version and translation version in parallel to avoid the double network penalty.
-            // Translation hash is only fetched if translations are enabled. Fetching translation cursor
-            // can never throw here, as in case of a failure we're returning a default value.
             const appVersion = await getAppVersion(request, config, s3)
 
             // Set app version header on request, so it can be picked up by the viewer response lambda

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -109,7 +109,7 @@ async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3C
  * If the preview name matches that pattern, we assume it's a hash preview link
  */
 function getPreviewHash(previewName?: string) {
-    const matchHash = /^preview-(?<hash>[a-z0-9]{40})$/.exec(previewName || '')
+    const matchHash = /^preview-(?<hash>[a-z0-9]{16}|[a-z0-9]{40})$/.exec(previewName || '')
     return matchHash?.groups?.hash
 }
 

--- a/terraform-module/edge-lambdas/tsconfig.json
+++ b/terraform-module/edge-lambdas/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es6",
+        "target": "ES2022",
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true


### PR DESCRIPTION
[WEB-1450: Support skipping app deployment on unrelated changes](https://linear.app/pleo/issue/WEB-1450/support-skipping-app-deployment-on-unrelated-changes)

Turbo hash has 16 instead of 40 characters, so we need to adjust the regex to accept both.

Old supported hash url: https://preview-6cd2b32ea72366adf21679cb796646184becd012.stories.dev.pleo.io/
New supported hash url: https://preview-ded26a748cdb93f8.stories.dev.pleo.io/

Also due to a TS error I've adjusted the tsconfig to use settings recommended for Node 18 based on [these docs](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)

I've confirmed that we use Node 18 for the edge lambdas [here](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)