### PR TITLE
feat!: Support using custom hash for build and deploy workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ on:
         required: true
         description: "Name of the S3 registry bucket"
         type: string
+      custom_hash:
+        required: false
+        description: "Custom hash used to cache the action on successful build"
+        type: string
       build_dir:
         required: true
         description: "Location of the deploy bundle after running the build command"
@@ -45,9 +49,9 @@ on:
         description: "Skip using Turborepo Remote Cache when build task (still writes task output to cache)"
         type: boolean
     outputs:
-      tree_hash:
-        description: "Tree hash of the code built"
-        value: ${{ jobs.build.outputs.tree_hash }}
+      build_hash:
+        description: "Hash of the code built"
+        value: ${{ jobs.build.outputs.build_hash }}
       bundle_uri:
         description: "S3 URI of the bundle in the registry bucket"
         value: ${{ jobs.build.outputs.bundle_uri }}
@@ -57,17 +61,18 @@ jobs:
     name: Build & Upload
     runs-on: ${{ inputs.runner }}
     outputs:
-      tree_hash: ${{ steps.s3-cache.outputs.hash }}
+      build_hash: ${{ steps.s3-cache.outputs.hash }}
       bundle_uri: ${{ steps.bundle-uri.outputs.uri }}
     steps:
       - uses: actions/checkout@v4.1.6
 
       - name: Check S3 Cache
-        uses: pleo-io/s3-cache-action@v3.0.0
+        uses: pleo-io/s3-cache-action@v3.1.0
         id: s3-cache
         with:
           bucket-name: ${{ inputs.bucket_name }}
           key-prefix: build/${{ inputs.app_name }}
+          custom-hash: ${{ inputs.custom_hash }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ on:
         default: "dist"
         description: "Directory where the bundle should be unpacked"
         type: string
-      tree_hash:
+      deploy_hash:
         required: true
         description: "Tree hash of the code to deploy"
         type: string
@@ -65,6 +65,25 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
 
+      - name: Setup AWS Credentials for Origin Bucket Access
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Check version already deployed
+        id: is-version-already-deployed
+        run: |
+          DEPLOY_EXISTS=$(aws s3 ls s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }}/ || true)
+          if [ -z "$DEPLOY_EXISTS" ]; then
+            echo "Version ${{ inputs.deploy_hash }} not yet deployed"
+            echo "is_deployed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version ${{ inputs.deploy_hash }} already deployed"
+            echo "is_deployed=true" >> $GITHUB_OUTPUT
+          fi
+
       # For feature preview deployments we're using the permalink as the deploy URL for the GitHub deployment
       # For deployments on the default branch we're using the domain name passed via inputs.
       - name: Get Deployment URL
@@ -75,17 +94,19 @@ jobs:
               echo "Could not determine default branch"
               exit 1
           fi
-          SUBDOMAIN=$([[ $GITHUB_REF = "refs/heads/$DEFAULT_BRANCH" || $GITHUB_REF = "refs/heads/change-freeze-emergency-deploy" ]] && echo "" || echo "preview-${{ inputs.tree_hash }}.")
+          SUBDOMAIN=$([[ $GITHUB_REF = "refs/heads/$DEFAULT_BRANCH" || $GITHUB_REF = "refs/heads/change-freeze-emergency-deploy" ]] && echo "" || echo "preview-${{ inputs.deploy_hash }}.")
           echo "url=https://${SUBDOMAIN}${{ inputs.domain_name }}" >> $GITHUB_OUTPUT
 
       - name: Setup AWS Credentials for Registry Bucket Access
         uses: aws-actions/configure-aws-credentials@v4.0.2
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - name: Download & Unpack Bundle
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
           aws s3 cp ${{ inputs.bundle_uri }} bundle.tar.gz
           mkdir ${{ inputs.bundle_dir }} && tar -xvzf bundle.tar.gz -C ${{ inputs.bundle_dir }}
@@ -98,45 +119,57 @@ jobs:
           aws-region: eu-west-1
 
       - name: Inject Environment Config
-        if: inputs.inject_config_cmd
+        if: inputs.inject_config_cmd != "" && ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
           SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
           SPA_ENV: ${{inputs.environment}}
-          SPA_TREE_HASH: ${{ inputs.tree_hash}}
+          SPA_TREE_HASH: ${{ inputs.deploy_hash }}
         run: ${{inputs.inject_config_cmd }}
 
       - name: Copy Static Files
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
           aws s3 cp ${{ inputs.bundle_dir }}/static s3://${{ inputs.bucket_name }}/static \
             --cache-control 'public,max-age=31536000,immutable' \
             --recursive
 
       - name: Copy HTML Files
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
-          aws s3 cp ${{ inputs.bundle_dir }}/ s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }} \
+          aws s3 cp ${{ inputs.bundle_dir }}/ s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }} \
            --cache-control 'public,max-age=31536000,immutable' \
            --recursive \
            --exclude "static/*"
 
       - name: Update .well-known Files If Exists
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
           aws s3 cp \
-           s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
-           s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
+           s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }}/.well-known/apple-app-site-association \
+           s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }}/.well-known/apple-app-site-association \
            --content-type 'application/json' \
            --cache-control 'public,max-age=3600' \
            --metadata-directive REPLACE || echo "Failed updating .well-known files"
 
+      # We always copy deploy hash file even if we don't do an actual deployemnt as part of this commit
+      # This is used to identify which version of the deployed app is associated with the current commit
+      # In case we trigger rollback to this commit, we know what deployment to use based on the stored deploy_hash for this commit
+      - name: Copy Deploy Hash File
+        run: |
+          echo ${{ inputs.deploy_hash }} >> ${{ github.sha }}
+          aws s3 cp ${{ github.sha }} s3://${{ inputs.bucket_name }}/deploys/commits/${{ github.sha }}
+
       - name: Update Cursor File
         id: cursor-update
-        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v9.0.2
+        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v10.0.0
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         with:
           bucket_name: ${{ inputs.bucket_name }}
 
       - name: Update PR Description
-        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v9.0.2
-        if: github.event_name == 'pull_request'
+        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v10.0.0
+        if: github.event_name == 'pull_request' && ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         with:
           app_name: ${{ inputs.app_name }}
           links: |
@@ -145,15 +178,7 @@ jobs:
               {"name": "Current Permalink", "url": "${{ steps.deployment-url.outputs.url }}"}
             ]
 
-      - name: Upload Deployed Bundle as Artifact
-        uses: actions/upload-artifact@v4.3.3
-        with:
-          name: bundle-${{ inputs.tree_hash }}-${{ inputs.environment }}
-          path: bundle.tar.gz
-
       - name: Verify app deployment
-        if: inputs.inject_config_cmd
-        # We expect the injection to insert the version in the HTML.
-        run:
-          curl --silent --show-error ${{ steps.deployment-url.outputs.url }} |
-          grep -q ${{ inputs.tree_hash }}
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
+        # We expect the viewer-request lambda to add the version in the response headers
+        run: curl --silent --head --show-error ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.deploy_hash }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ on:
         type: string
       deploy_hash:
         required: true
-        description: "Tree hash of the code to deploy"
+        description: "Hash of the code to deploy, this is usually the build hash provided from the build step"
         type: string
       bucket_name:
         required: true

--- a/actions/utils.test.ts
+++ b/actions/utils.test.ts
@@ -27,29 +27,6 @@ describe(`Actions Utils`, () => {
         expect(output).toBe(false)
     })
 
-    test(`getTreeHashForCommitHash uses git CLI to check if the commit is part of the current branch, returns false when it is not`, async () => {
-        mockedExec.mockResolvedValue(0)
-        const hash = '5265ef99f1c8e18bcd282a11a4b752731cad5665'
-        const output = await utils.getTreeHashForCommitHash(hash)
-        expect(mockedExec).toHaveBeenCalledWith(
-            'git rev-parse',
-            ['5265ef99f1c8e18bcd282a11a4b752731cad5665:'],
-            {
-                listeners: {stdout: expect.any(Function)}
-            }
-        )
-        expect(output).toBe('')
-    })
-
-    test(`getCurrentRepoTreeHash uses git CLI to return the latest tree hash of the root of the repo`, async () => {
-        mockedExec.mockResolvedValue(0)
-        const output = await utils.getCurrentRepoTreeHash()
-        expect(mockedExec).toHaveBeenCalledWith('git rev-parse', ['HEAD:'], {
-            listeners: {stdout: expect.any(Function)}
-        })
-        expect(output).toBe('')
-    })
-
     test(`writeLineToFile creates a file using a shell script`, async () => {
         mockedExec.mockResolvedValue(0)
         await utils.writeLineToFile({path: '/some/file', text: 'hello world'})
@@ -65,6 +42,15 @@ describe(`Actions Utils`, () => {
                 '--key=my/key'
             ])
             expect(output).toBe(true)
+        })
+
+        test(`getCommitHashFromRef uses git CLI to return the latest tree hash of the root of the repo`, async () => {
+            mockedExec.mockResolvedValue(0)
+            const output = await utils.getCommitHashFromRef('HEAD')
+            expect(mockedExec).toHaveBeenCalledWith('git rev-parse', ['HEAD'], {
+                listeners: {stdout: expect.any(Function)}
+            })
+            expect(output).toBe('')
         })
 
         test(`fileExistsInS3 uses AWS CLI to check for of an object in S3 bucket, returns true if it exists`, async () => {

--- a/actions/utils.test.ts
+++ b/actions/utils.test.ts
@@ -44,7 +44,7 @@ describe(`Actions Utils`, () => {
             expect(output).toBe(true)
         })
 
-        test(`getCommitHashFromRef uses git CLI to return the latest tree hash of the root of the repo`, async () => {
+        test(`getCommitHashFromRef uses git CLI to return the latest commit hash of the repo`, async () => {
             mockedExec.mockResolvedValue(0)
             const output = await utils.getCommitHashFromRef('HEAD')
             expect(mockedExec).toHaveBeenCalledWith('git rev-parse', ['HEAD'], {

--- a/reusable-workflows/build.yml
+++ b/reusable-workflows/build.yml
@@ -13,6 +13,10 @@ on:
         required: true
         description: "Name of the S3 registry bucket"
         type: string
+      custom_hash:
+        required: false
+        description: "Custom hash used to cache the action on successful build"
+        type: string
       build_dir:
         required: true
         description: "Location of the deploy bundle after running the build command"
@@ -45,9 +49,9 @@ on:
         description: "Skip using Turborepo Remote Cache when build task (still writes task output to cache)"
         type: boolean
     outputs:
-      tree_hash:
-        description: "Tree hash of the code built"
-        value: ${{ jobs.build.outputs.tree_hash }}
+      build_hash:
+        description: "Hash of the code built"
+        value: ${{ jobs.build.outputs.build_hash }}
       bundle_uri:
         description: "S3 URI of the bundle in the registry bucket"
         value: ${{ jobs.build.outputs.bundle_uri }}
@@ -57,17 +61,18 @@ jobs:
     name: Build & Upload
     runs-on: ${{ inputs.runner }}
     outputs:
-      tree_hash: ${{ steps.s3-cache.outputs.hash }}
+      build_hash: ${{ steps.s3-cache.outputs.hash }}
       bundle_uri: ${{ steps.bundle-uri.outputs.uri }}
     steps:
       - uses: actions/checkout@v4.1.6
 
       - name: Check S3 Cache
-        uses: pleo-io/s3-cache-action@v3.0.0
+        uses: pleo-io/s3-cache-action@v3.1.0
         id: s3-cache
         with:
           bucket-name: ${{ inputs.bucket_name }}
           key-prefix: build/${{ inputs.app_name }}
+          custom-hash: ${{ inputs.custom_hash }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -22,7 +22,7 @@ on:
         default: "dist"
         description: "Directory where the bundle should be unpacked"
         type: string
-      tree_hash:
+      deploy_hash:
         required: true
         description: "Tree hash of the code to deploy"
         type: string
@@ -65,6 +65,25 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
 
+      - name: Setup AWS Credentials for Origin Bucket Access
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Check version already deployed
+        id: is-version-already-deployed
+        run: |
+          DEPLOY_EXISTS=$(aws s3 ls s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }}/ || true)
+          if [ -z "$DEPLOY_EXISTS" ]; then
+            echo "Version ${{ inputs.deploy_hash }} not yet deployed"
+            echo "is_deployed=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version ${{ inputs.deploy_hash }} already deployed"
+            echo "is_deployed=true" >> $GITHUB_OUTPUT
+          fi
+
       # For feature preview deployments we're using the permalink as the deploy URL for the GitHub deployment
       # For deployments on the default branch we're using the domain name passed via inputs.
       - name: Get Deployment URL
@@ -75,17 +94,19 @@ jobs:
               echo "Could not determine default branch"
               exit 1
           fi
-          SUBDOMAIN=$([[ $GITHUB_REF = "refs/heads/$DEFAULT_BRANCH" || $GITHUB_REF = "refs/heads/change-freeze-emergency-deploy" ]] && echo "" || echo "preview-${{ inputs.tree_hash }}.")
+          SUBDOMAIN=$([[ $GITHUB_REF = "refs/heads/$DEFAULT_BRANCH" || $GITHUB_REF = "refs/heads/change-freeze-emergency-deploy" ]] && echo "" || echo "preview-${{ inputs.deploy_hash }}.")
           echo "url=https://${SUBDOMAIN}${{ inputs.domain_name }}" >> $GITHUB_OUTPUT
 
       - name: Setup AWS Credentials for Registry Bucket Access
         uses: aws-actions/configure-aws-credentials@v4.0.2
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
           aws-region: eu-west-1
 
       - name: Download & Unpack Bundle
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
           aws s3 cp ${{ inputs.bundle_uri }} bundle.tar.gz
           mkdir ${{ inputs.bundle_dir }} && tar -xvzf bundle.tar.gz -C ${{ inputs.bundle_dir }}
@@ -98,45 +119,57 @@ jobs:
           aws-region: eu-west-1
 
       - name: Inject Environment Config
-        if: inputs.inject_config_cmd
+        if: inputs.inject_config_cmd != "" && ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
           SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
           SPA_ENV: ${{inputs.environment}}
-          SPA_TREE_HASH: ${{ inputs.tree_hash}}
+          SPA_TREE_HASH: ${{ inputs.deploy_hash }}
         run: ${{inputs.inject_config_cmd }}
 
       - name: Copy Static Files
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
           aws s3 cp ${{ inputs.bundle_dir }}/static s3://${{ inputs.bucket_name }}/static \
             --cache-control 'public,max-age=31536000,immutable' \
             --recursive
 
       - name: Copy HTML Files
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
-          aws s3 cp ${{ inputs.bundle_dir }}/ s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }} \
+          aws s3 cp ${{ inputs.bundle_dir }}/ s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }} \
            --cache-control 'public,max-age=31536000,immutable' \
            --recursive \
            --exclude "static/*"
 
       - name: Update .well-known Files If Exists
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         run: |
           aws s3 cp \
-           s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
-           s3://${{ inputs.bucket_name }}/html/${{ inputs.tree_hash }}/.well-known/apple-app-site-association \
+           s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }}/.well-known/apple-app-site-association \
+           s3://${{ inputs.bucket_name }}/html/${{ inputs.deploy_hash }}/.well-known/apple-app-site-association \
            --content-type 'application/json' \
            --cache-control 'public,max-age=3600' \
            --metadata-directive REPLACE || echo "Failed updating .well-known files"
 
+      # We always copy deploy hash file even if we don't do an actual deployemnt as part of this commit
+      # This is used to identify which version of the deployed app is associated with the current commit
+      # In case we trigger rollback to this commit, we know what deployment to use based on the stored deploy_hash for this commit
+      - name: Copy Deploy Hash File
+        run: |
+          echo ${{ inputs.deploy_hash }} >> ${{ github.sha }}
+          aws s3 cp ${{ github.sha }} s3://${{ inputs.bucket_name }}/deploys/commits/${{ github.sha }}
+
       - name: Update Cursor File
         id: cursor-update
-        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v9.0.2
+        uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v10.0.0
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         with:
           bucket_name: ${{ inputs.bucket_name }}
 
       - name: Update PR Description
-        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v9.0.2
-        if: github.event_name == 'pull_request'
+        uses: pleo-io/spa-tools/actions/post-preview-urls@spa-github-actions-v10.0.0
+        if: github.event_name == 'pull_request' && ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         with:
           app_name: ${{ inputs.app_name }}
           links: |
@@ -145,15 +178,7 @@ jobs:
               {"name": "Current Permalink", "url": "${{ steps.deployment-url.outputs.url }}"}
             ]
 
-      - name: Upload Deployed Bundle as Artifact
-        uses: actions/upload-artifact@v4.3.3
-        with:
-          name: bundle-${{ inputs.tree_hash }}-${{ inputs.environment }}
-          path: bundle.tar.gz
-
       - name: Verify app deployment
-        if: inputs.inject_config_cmd
-        # We expect the injection to insert the version in the HTML.
-        run:
-          curl --silent --show-error ${{ steps.deployment-url.outputs.url }} |
-          grep -q ${{ inputs.tree_hash }}
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
+        # We expect the viewer-request lambda to add the version in the response headers
+        run: curl --silent --head --show-error ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.deploy_hash }}

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -24,7 +24,7 @@ on:
         type: string
       deploy_hash:
         required: true
-        description: "Tree hash of the code to deploy"
+        description: "Hash of the code to deploy, this is usually the build hash provided from the build step"
         type: string
       bucket_name:
         required: true


### PR DESCRIPTION
Changes tested in https://github.com/pleo-io/product-web/pull/16898

Successful deploy of storybook using these changes https://github.com/pleo-io/product-web/actions/runs/10815344936

So far we only used the root tree hash of a repository as an identifier for app deployment (storybook, product-web, backoffice)

These changes enable us to provide custom hash instead (calculated by Turborepo)

Deploy step is adjusted so that we don't re-deploy the app if we receive a hash that has already been deployed.

We now also create a new file for each run in S3 under deploys/commits, where:
filename - current deploy commit hash
content - current deploy hash (this is the turbo hash)

In the "Update Cursor File" step we now use this file to set cursor file for branch to that

Introduction of the new file is necessary to support the rollback workflow. We can still use a github commit hash to rollback app deploy to a version associated with that commit hash.