### PR TITLE
fix: Always deploy version when workflow runs on default branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Update Cursor File
         id: cursor-update
         uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v10.0.0
-        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false' || github.ref_name == github.event.repository.default_branch }}
         with:
           bucket_name: ${{ inputs.bucket_name }}
 

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Update Cursor File
         id: cursor-update
         uses: pleo-io/spa-tools/actions/cursor-deploy@spa-github-actions-v10.0.0
-        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
+        if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false' || github.ref_name == github.event.repository.default_branch }}
         with:
           bucket_name: ${{ inputs.bucket_name }}
 


### PR DESCRIPTION
We are skipping deployments on main because the same code has already been deployed to a feature branch.

However, on main we always want to trigger updating the cursor file.