### PR TITLE
feat: support specifying rootDir in config inject script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ on:
         required: true
         description: "S3 URI of the bundle in the registry bucket"
         type: string
+      root_dir:
+        required: false
+        description: "Directory where the project root is located"
+        type: string
       bundle_dir:
         required: false
         default: "dist"
@@ -126,6 +130,7 @@ jobs:
         if: ${{ inputs.inject_config_cmd && steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
+          SPA_ROOT_DIR: ${{ inputs.root_dir }}
           SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
           SPA_ENV: ${{inputs.environment}}
           SPA_TREE_HASH: ${{ inputs.deploy_hash }}

--- a/config-inject/src/shared/load-config.ts
+++ b/config-inject/src/shared/load-config.ts
@@ -15,13 +15,13 @@ Loads and validates the configuration from package.json.
 If the configuration is invalid, it logs the error and exits the process.
 @returns Returns the parsed and validated configuration object.
 */
-export async function loadConfig() {
-    const rawConfig = await getRawConfig()
+export async function loadConfig(rootDir?: string) {
+    const rawConfig = await getRawConfig(rootDir)
     return parseConfig(rawConfig)
 }
 
-async function getRawConfig() {
-    const pkgJSON = readFileSync(path.resolve('package.json'), 'utf-8')
+async function getRawConfig(rootDir?: string) {
+    const pkgJSON = readFileSync(path.resolve(rootDir ?? '', 'package.json'), 'utf-8')
     return JSON.parse(pkgJSON).spaConfig
 }
 

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -21,6 +21,10 @@ on:
         required: true
         description: "S3 URI of the bundle in the registry bucket"
         type: string
+      root_dir:
+        required: false
+        description: "Directory where the project root is located"
+        type: string
       bundle_dir:
         required: false
         default: "dist"
@@ -126,6 +130,7 @@ jobs:
         if: ${{ inputs.inject_config_cmd && steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
+          SPA_ROOT_DIR: ${{ inputs.root_dir }}
           SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
           SPA_ENV: ${{inputs.environment}}
           SPA_TREE_HASH: ${{ inputs.deploy_hash }}


### PR DESCRIPTION
This is necessary to inject environment config to an app that isn't located in root of a repo
Fixes this error in CI: https://github.com/pleo-io/product-web/actions/runs/11363740302/job/31608516867?pr=17471

I only assume this will work, need to publish this in order to test it in the CI in product-web repo. Would be great to make this part of product-web so that I don't need to merge and publish the change in order to test it 🙂 