### PR TITLE
fix: Install dependencies in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,11 +67,27 @@ jobs:
       deployment_url: ${{ steps.deployment-url.outputs.url }}
     steps:
       - uses: actions/checkout@v4.1.4
+
+      - uses: pnpm/action-setup@v4.0.0
+
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: "20"
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
+
+      - name: Cache node_modules/.pnpm
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules/.pnpm
+          key: pnpm-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-node-modules-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
 
       - name: Setup AWS Credentials for Origin Bucket Access
         uses: aws-actions/configure-aws-credentials@v4.0.2

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -67,11 +67,27 @@ jobs:
       deployment_url: ${{ steps.deployment-url.outputs.url }}
     steps:
       - uses: actions/checkout@v4.1.4
+
+      - uses: pnpm/action-setup@v4.0.0
+
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: "20"
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
+
+      - name: Cache node_modules/.pnpm
+        uses: actions/cache@v4.0.2
+        with:
+          path: node_modules/.pnpm
+          key: pnpm-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-node-modules-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
 
       - name: Setup AWS Credentials for Origin Bucket Access
         uses: aws-actions/configure-aws-credentials@v4.0.2


### PR DESCRIPTION
This is necessary to be able to run local version of spa-config-inject inside the monorepo

Unfortunately this makes feature deploy job ~10 seconds longer but can't think of another way how to do this

Tested in this job https://github.com/pleo-io/product-web/actions/runs/11386132550/job/31677900661