### PR TITLE
fix!: Distinguish between "Pleo" env and Github env in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,11 @@ on:
     inputs:
       environment:
         required: true
-        description: "Name of the deployment environment"
+        description: "Name of the deployment environment (product-{dev|staging|production})"
+        type: string
+      github_environment:
+        required: true
+        description: "Name of the Github deployment environment ({app_name}-{environment})"
         type: string
       app_name:
         required: false
@@ -61,7 +65,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-22.04
     environment:
-      name: ${{ inputs.environment  }}
+      name: ${{ inputs.github_environment  }}
       url: ${{ steps.deployment-url.outputs.url }}
     outputs:
       deployment_url: ${{ steps.deployment-url.outputs.url }}
@@ -148,9 +152,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
           SPA_ROOT_DIR: ${{ inputs.root_dir }}
           SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
-          SPA_ENV: ${{inputs.environment}}
+          SPA_ENV: ${{ inputs.environment }}
           SPA_TREE_HASH: ${{ inputs.deploy_hash }}
-        run: ${{inputs.inject_config_cmd }}
+        run: ${{ inputs.inject_config_cmd }}
 
       - name: Copy Static Files
         if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -7,7 +7,11 @@ on:
     inputs:
       environment:
         required: true
-        description: "Name of the deployment environment"
+        description: "Name of the deployment environment (product-{dev|staging|production})"
+        type: string
+      github_environment:
+        required: true
+        description: "Name of the Github deployment environment ({app_name}-{environment})"
         type: string
       app_name:
         required: false
@@ -61,7 +65,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-22.04
     environment:
-      name: ${{ inputs.environment  }}
+      name: ${{ inputs.github_environment  }}
       url: ${{ steps.deployment-url.outputs.url }}
     outputs:
       deployment_url: ${{ steps.deployment-url.outputs.url }}
@@ -148,9 +152,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_NPM_TOKEN }}
           SPA_ROOT_DIR: ${{ inputs.root_dir }}
           SPA_BUNDLE_DIR: ${{ inputs.bundle_dir }}
-          SPA_ENV: ${{inputs.environment}}
+          SPA_ENV: ${{ inputs.environment }}
           SPA_TREE_HASH: ${{ inputs.deploy_hash }}
-        run: ${{inputs.inject_config_cmd }}
+        run: ${{ inputs.inject_config_cmd }}
 
       - name: Copy Static Files
         if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}


### PR DESCRIPTION
Fixes the following deploy error https://github.com/pleo-io/product-web/actions/runs/11483548110/job/31959328063

Currently it is expected that the name of Github environment we deploy to matches one of the "Pleo" environments as we define them in the [Environment type](https://github.com/pleo-io/product-web/blob/71410a90bb6a208f3b6f9c8cc26e88e816d5eaaf/shared/config/config.type.ts#L1)

This is problematic for the [spa-config-inject](https://github.com/pleo-io/product-web/blob/9d58d032ea8b82eb815200fa2f570b12d16e3c68/published-packages/spa-config-inject/src/cli.ts#L75) script which uses the name of the Github environment to find the appropriate config file.

We can't deploy multiple apps from one repo to the same Github environment.