### PR TITLE
fix: upate version of actions/cache in wiz-cli step

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "complete_version=$COMPLETE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Cache Wiz CLI
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: cache_wizcli
         with:
           path: wizcli-${{ steps.version_check.outputs.version }}


### PR DESCRIPTION
I missed one version of the cache action in this wiz-cli step.
I think this should be managed by renovate, not sure why there is no PR