### PR TITLE
chore: Move the website to latest TLS 1.2 cipher suite

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -94,7 +94,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.acm_certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2018"
+    minimum_protocol_version = "TLSv1.2_2021"
   }
 
   tags = {


### PR DESCRIPTION
Similar to https://github.com/pleo-io/commercial-helios/pull/5265