### PR TITLE
fix: Fail verify app deployment if we get non-200 response

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,4 +223,4 @@ jobs:
       - name: Verify app deployment
         if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         # We expect the viewer-request lambda to add the version in the response headers
-        run: curl --silent --head --show-error ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.deploy_hash }}
+        run: curl --silent --head --show-error --fail ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.deploy_hash }}

--- a/reusable-workflows/deploy.yml
+++ b/reusable-workflows/deploy.yml
@@ -223,4 +223,4 @@ jobs:
       - name: Verify app deployment
         if: ${{ steps.is-version-already-deployed.outputs.is_deployed == 'false'}}
         # We expect the viewer-request lambda to add the version in the response headers
-        run: curl --silent --head --show-error ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.deploy_hash }}
+        run: curl --silent --head --show-error --fail ${{ steps.deployment-url.outputs.url }} | grep -q ${{ inputs.deploy_hash }}


### PR DESCRIPTION
https://linear.app/pleo/issue/WEB-1964/fix-deploy-workflows-verify-app-deployment-step-when-inject

At first I made changes to our deployment workflow to be able to deploy an app without using `spa-config-inject`.
However I later found out that it is already possible to do that (see [comment](https://linear.app/pleo/issue/WEB-1964/fix-deploy-workflows-verify-app-deployment-step-when-inject#comment-597892a8))

I've reverted the changes, but decided to keep the improvement to fail `curl` on non-200 response