### PR TITLE
fix: ME-7412 Pleo Account Takeover via stealing Google OAuth

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -250,7 +250,7 @@ resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour
       value    = "max-age=0,no-cache,no-store,must-revalidate"
     }
 
-    // Adds robots tag HTTP header to the response to prevent indexing by bots (unless in production)
+    // Adds robots tag HTTP header to the response to prevent indexing by bots
     items {
       header   = "X-Robots-Tag"
       override = true

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -169,7 +169,7 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
     items {
       header   = "Cross-Origin-Opener-Policy"
       override = true
-      value    = "same-origin"
+      value    = "same-origin-allow-popups"
     }
   }
 }

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -82,6 +82,32 @@ resource "aws_cloudfront_distribution" "this" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  # Cache behaviour applying to specific path: /loading.html
+  # To allow sharing the browsing context group with the opener page
+  # This is needed to set up connection with 3rd party integrations
+  ordered_cache_behavior {
+    path_pattern     = "/loading.html"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.loading_integration_behaviour_headers_policy.id
+
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 1
+    default_ttl            = 86400
+    max_ttl                = 31536000
+  }
+
   # Serve a custom 404 error page when requesting a file that doesn't exist in the bucket 
   custom_error_response {
     error_caching_min_ttl = 10
@@ -170,6 +196,64 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
       header   = "Cross-Origin-Opener-Policy"
       override = true
       value    = "same-origin-allow-popups"
+    }
+  }
+}
+
+// This is custom headers policy for /loading.html page
+// This page is used as an intermediate page for 3rd party integration connections
+// And it should have ability to share same browsing context group with the opener page
+resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour_headers_policy" {
+  name = "${var.app_name}-default-headers-policy"
+  security_headers_config {
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = var.block_iframes ? "DENY" : "SAMEORIGIN"
+      override     = true
+    }
+    referrer_policy {
+      referrer_policy = "same-origin"
+      override        = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+    strict_transport_security {
+      access_control_max_age_sec = "63072000"
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+  }
+
+  custom_headers_config {
+
+    // Adds cache control HTTP headers to the response to remove any caching
+    // Since we're only handling skeleton HTML files in this behaviour, disabling
+    // caching has little performance overhead. All static assets are cached aggressively
+    // in another behaviour.
+    items {
+      header   = "Cache-Control"
+      override = true
+      value    = "max-age=0,no-cache,no-store,must-revalidate"
+    }
+
+    // Adds robots tag HTTP header to the response to prevent indexing by bots (unless in production)
+    items {
+      header   = "X-Robots-Tag"
+      override = true
+      value    = var.is_robots_indexing_allowed && var.env == "production" ? "all" : "noindex, nofollow"
+    }
+
+    // using unsafe-none to explicitly allow sharing the browsing context group with the opener page
+    items {
+      header   = "Cross-Origin-Opener-Policy"
+      override = true
+      value    = "unsafe-none"
     }
   }
 }

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -75,6 +75,14 @@ resource "aws_cloudfront_distribution" "this" {
       }
     }
 
+    dynamic "lambda_function_association" {
+      for_each = var.edge_lambdas
+      content {
+        event_type = lambda_function_association.value["event_type"]
+        lambda_arn = lambda_function_association.value["arn"]
+      }
+    }
+
     response_headers_policy_id = aws_cloudfront_response_headers_policy.loading_integration_behaviour_headers_policy.id
 
     compress               = true

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -204,7 +204,7 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
 // This page is used as an intermediate page for 3rd party integration connections
 // And it should have ability to share same browsing context group with the opener page
 resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour_headers_policy" {
-  name = "${var.app_name}-default-headers-policy"
+  name = "${var.app_name}-loading-integration-headers-policy"
   security_headers_config {
     content_type_options {
       override = true

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -254,7 +254,7 @@ resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour
     items {
       header   = "X-Robots-Tag"
       override = true
-      value    = var.is_robots_indexing_allowed && var.env == "production" ? "all" : "noindex, nofollow"
+      value    =  "noindex, nofollow"
     }
 
     // using unsafe-none to explicitly allow sharing the browsing context group with the opener page

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -58,30 +58,6 @@ resource "aws_cloudfront_distribution" "this" {
     max_ttl                = 31536000
   }
 
-  # Cache behaviour applying to all files prefixed with /static
-  # To optimise latency we don't have any lambda assosiations and
-  # the TTL rules allow for optimal caching
-  ordered_cache_behavior {
-    path_pattern     = "/static/*"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = local.s3_origin_id
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-
-    min_ttl                = 1
-    default_ttl            = 86400
-    max_ttl                = 31536000
-    compress               = true
-    viewer_protocol_policy = "redirect-to-https"
-  }
-
   # Cache behaviour applying to specific path: /loading.html
   # To allow sharing the browsing context group with the opener page
   # This is needed to set up connection with 3rd party integrations
@@ -106,6 +82,30 @@ resource "aws_cloudfront_distribution" "this" {
     min_ttl                = 1
     default_ttl            = 86400
     max_ttl                = 31536000
+  }
+
+  # Cache behaviour applying to all files prefixed with /static
+  # To optimise latency we don't have any lambda assosiations and
+  # the TTL rules allow for optimal caching
+  ordered_cache_behavior {
+    path_pattern     = "/static/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 1
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
   }
 
   # Serve a custom 404 error page when requesting a file that doesn't exist in the bucket 

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -161,5 +161,15 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
       override = true
       value    = var.is_robots_indexing_allowed && var.env == "production" ? "all" : "noindex, nofollow"
     }
+
+    // If page is opened via window.open() or by navigating to a new page
+    // it will be opened in a new browsing context group
+    // unless opener has the same origin as the target page.
+    // This prevents sharing the browsing context group with potentially malicious opener page
+    items {
+      header   = "Cross-Origin-Opener-Policy"
+      override = true
+      value    = "same-origin"
+    }
   }
 }


### PR DESCRIPTION
In this PR we're adding customer header `Cross-Origin-Opener-Policy: same-origin` to index.html
so when app.pelo.io is opened by a parent website using wither window.open() or via clicking to a link - browser context is not shared between child and potentially malicious parent windows.


More details [here](https://getpleo.slack.com/archives/C0324UJ3EJE/p1744725605267889)

[Respective terraform PR](https://github.com/pleo-io/terraform/pull/9228) for testing purposes ([env0](https://www.notion.so/pleo/How-to-test-Terraform-changes-before-merging-using-env0-e639098417574a97ae180e9c9b7e644f))