### PR TITLE
fix!: formatting & treat coop header as breaking change

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -254,7 +254,7 @@ resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour
     items {
       header   = "X-Robots-Tag"
       override = true
-      value    =  "noindex, nofollow"
+      value    = "noindex, nofollow"
     }
 
     // using unsafe-none to explicitly allow sharing the browsing context group with the opener page


### PR DESCRIPTION
we had accidentally merged #283 as a bugfix release, but adding the cross-origin-opener-policy header can break integrations and should be treated as a breaking change. This PR just adjusts formatting but has the conventional-commits code for a breaking change, so the next release will be treated as a major version.