### PR TITLE
feat(frontend-spa-dns): Add in app.demo.pleo.io as staging alternative

### DIFF
--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -69,7 +69,7 @@ module "dns" {
 
   zone_domain = var.zone_domain
   domain_name = local.domain_name
-  app_name    = var.app_name
+  subdomain   = var.subdomain
 
   cf_hosted_zone_id = module.cdn.cf_hosted_zone_id
   cf_domain_name    = module.cdn.cf_domain_name

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -69,6 +69,7 @@ module "dns" {
 
   zone_domain = var.zone_domain
   domain_name = local.domain_name
+  app_name    = var.app_name
 
   cf_hosted_zone_id = module.cdn.cf_hosted_zone_id
   cf_domain_name    = module.cdn.cf_domain_name

--- a/terraform-module/modules/frontend-spa-dns/main.tf
+++ b/terraform-module/modules/frontend-spa-dns/main.tf
@@ -39,12 +39,14 @@ resource "aws_route53_record" "dns_record" {
   }
 }
 
-// Request for app.demo.pleo.io from ask-SRE ticket SRE-7285
+# Based on request SRE-7285 to provide better demo experience
+# Creates ${app_name}.demo.pleo.io record that redirects to the staging env
+# Records are created on product-production env, because we need to evaluate at pleo.io level (not staging.pleo.io).
 resource "aws_route53_record" "demo_dns_record" {
-    for_each = lower(var.env) == "production" ? local.naked : {}
-    
-    name    = "app.demo.${var.zone_domain}"
-    type    = "CNAME"
-    zone_id = each.value[1]
-    records = ["app.staging.pleo.io"]
+  for_each = lower(var.env) == "production" ? local.naked : {}
+
+  name    = "${var.app_name}.demo.${var.zone_domain}"
+  type    = "CNAME"
+  zone_id = each.value[1]
+  records = ["${var.app_name}.staging.pleo.io"]
 }

--- a/terraform-module/modules/frontend-spa-dns/main.tf
+++ b/terraform-module/modules/frontend-spa-dns/main.tf
@@ -38,3 +38,13 @@ resource "aws_route53_record" "dns_record" {
     evaluate_target_health = false
   }
 }
+
+// Request for app.demo.pleo.io from ask-SRE ticket SRE-7285
+resource "aws_route53_record" "demo_dns_record" {
+    for_each = lower(var.env) == "production" ? local.naked : {}
+    
+    name    = "app.demo.${var.zone_domain}"
+    type    = "CNAME"
+    zone_id = each.value[1]
+    records = ["app.staging.pleo.io"]
+}

--- a/terraform-module/modules/frontend-spa-dns/main.tf
+++ b/terraform-module/modules/frontend-spa-dns/main.tf
@@ -40,13 +40,13 @@ resource "aws_route53_record" "dns_record" {
 }
 
 # Based on request SRE-7285 to provide better demo experience
-# Creates ${app_name}.demo.pleo.io record that redirects to the staging env
+# Creates ${subdomain}.demo.pleo.io record that redirects to the staging env
 # Records are created on product-production env, because we need to evaluate at pleo.io level (not staging.pleo.io).
 resource "aws_route53_record" "demo_dns_record" {
   for_each = lower(var.env) == "production" ? local.naked : {}
 
-  name    = "${var.app_name}.demo.${var.zone_domain}"
+  name    = "${var.subdomain}.demo.${var.zone_domain}"
   type    = "CNAME"
   zone_id = each.value[1]
-  records = ["${var.app_name}.staging.pleo.io"]
+  records = ["${var.subdomain}.staging.pleo.io"]
 }

--- a/terraform-module/modules/frontend-spa-dns/vars.tf
+++ b/terraform-module/modules/frontend-spa-dns/vars.tf
@@ -13,8 +13,8 @@ variable "domain_name" {
   type        = string
 }
 
-variable "app_name" {
-  description = "Name of the app (kebab-case)"
+variable "subdomain" {
+  description = "Subdomain where the app lives (e.g. 'hello' if the app lives at hello.example.com)"
   type        = string
 }
 

--- a/terraform-module/modules/frontend-spa-dns/vars.tf
+++ b/terraform-module/modules/frontend-spa-dns/vars.tf
@@ -13,6 +13,11 @@ variable "domain_name" {
   type        = string
 }
 
+variable "app_name" {
+  description = "Name of the app (kebab-case)"
+  type        = string
+}
+
 variable "cf_domain_name" {
   description = "The domain name corresponding to the CloudFront distribution."
   type        = string


### PR DESCRIPTION
Hi guys 👋 
This is a request from Demo team, that came in [via ask-SRE](https://linear.app/pleo/issue/SRE-7285/explore-dns-configuration-for-cleaner-demo-environment-urls)

Essentially, we (Pleo) want to portray a better image to potential customers when giving demos. Instead of directing customers to `app.staging.pleo.io`, we want them to use `app.demo.pleo.io`.

I think it should be a simple DNS addition, and we want to keep the `app.demo` record close to wherever the `app.staging` record is kept (which is here in _spa-tools_).
I could do with a proper review on the changes, as I'm not entirely sure I've done this correctly inline with the current setup.

I'm using the same `for_loop` to create a CNAME record in both public & private.
I'm creating them on _product-production_, because we need to evaluate at the `pleo.io` level (not `staging.pleo.io`).
I didn't include the wildcards (typical for staging) because I don't think demos would be interested in feature-deploys.

I'm pretty sure we don't need to add anything around certificates, because we just redirect any calls to `app.staging.pleo.io`, and so I am thinking any certificate magic will be handled there (in the normal way)

