### PR TITLE
feat(certificates): Enable passing in additional SANs to certificates

### DIFF
--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -77,6 +77,7 @@ No resources.
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
+| <a name="input_certificate_additional_sans"></a> [certificate\_additional\_sans](#input\_certificate\_additional\_sans) | Additional subject alternative names to include in the certificate | `list(string)` | `[]` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
 | <a name="input_is_robots_indexing_allowed"></a> [is\_robots\_indexing\_allowed](#input\_is\_robots\_indexing\_allowed) | Should allow search engine indexing in production? | `bool` | `true` | no |

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -41,8 +41,7 @@ module "certificate" {
   zone_domain = var.zone_domain
   domain_name = local.domain_name
   
-  // Support demo.pleo.io alternative for better demo experience
-  additional_subject_alternative_names = lower(var.env) == "staging" ? ["demo.pleo.io"] : []
+  additional_subject_alternative_names = var.certificate_additional_sans
 
   providers = {
     aws.global = aws.global

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -40,6 +40,9 @@ module "certificate" {
   env         = var.env
   zone_domain = var.zone_domain
   domain_name = local.domain_name
+  
+  // Support demo.pleo.io alternative for better demo experience
+  additional_subject_alternative_names = lower(var.env) == "staging" ? [] : ["demo.pleo.io"]
 
   providers = {
     aws.global = aws.global

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -42,7 +42,7 @@ module "certificate" {
   domain_name = local.domain_name
   
   // Support demo.pleo.io alternative for better demo experience
-  additional_subject_alternative_names = lower(var.env) == "staging" ? [] : ["demo.pleo.io"]
+  additional_subject_alternative_names = lower(var.env) == "staging" ? ["demo.pleo.io"] : []
 
   providers = {
     aws.global = aws.global

--- a/terraform-module/modules/frontend-spa-certificate/main.tf
+++ b/terraform-module/modules/frontend-spa-certificate/main.tf
@@ -8,12 +8,17 @@ data "aws_route53_zone" "public" {
   name         = var.zone_domain
   private_zone = false
 }
+
+locals {
+  wildcard_san = lower(var.env) == "production" ? [] : ["*.${var.domain_name}"]
+}
+
 resource "aws_acm_certificate" "this" {
   provider          = aws.global
   domain_name       = var.domain_name
   validation_method = "DNS"
 
-  subject_alternative_names = lower(var.env) == "production" ? [] : ["*.${var.domain_name}"]
+  subject_alternative_names = concat(local.wildcard_san, var.additional_subject_alternative_names)
 
   tags = {
     Environment = var.env

--- a/terraform-module/modules/frontend-spa-certificate/vars.tf
+++ b/terraform-module/modules/frontend-spa-certificate/vars.tf
@@ -12,3 +12,9 @@ variable "domain_name" {
   description = "Full domain name of the app"
   type        = string
 }
+
+variable "additional_subject_alternative_names" {
+  description = "Additional subject alternative names to include in the certificate"
+  type        = list(string)
+  default     = []
+}

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -45,3 +45,9 @@ variable "serve_nested_index_html" {
   description = "Applies to apps which build separate index.html files for sub-routes, e.g. using Gatsby SSG"
   type        = bool
 }
+
+variable "certificate_additional_sans" {
+  description = "Additional subject alternative names to include in the certificate"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Adds in ability to pass additional _subject-alternative-names_ (SAN) to certificate module.
We use this to include `demo.pleo.io` as a SAN for the `app.staging.pleo.io` certificate. We need this to support addition of the `demo.pleo.io` domain that demo teams will use for a slicker demo experience ([PR here](https://github.com/pleo-io/terraform/pull/9203))

Tested in [PR9381](https://github.com/pleo-io/terraform/pull/9381).
The crucial part: we see [_product-staging_](https://app.env0.com/p/3d157998-4b5a-4862-87e2-5f947d32acdd/environments/1dbd2166-eefa-4f35-9b14-8bc5bc095284/deployments/be5820c4-a30e-44c4-907c-ca5152edc886) gets additional certificate updates to include `demo.pleo.io`
Both _product-dev_ & _product-production_ have no certificate-related changes, as expected.