### PR TITLE
feat(frontend-spa-cdn): Move to V2 Cloudfront logging

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -142,33 +142,33 @@ resource "aws_cloudfront_distribution" "this" {
   }
 }
 
-resource "aws_cloudwatch_log_delivery_source" "cloudfront_log_source" {
-  region = "eu-west-1"
+resource "aws_cloudwatch_log_delivery_source" "this" {
+  region = module.data_aws_core.region
 
-  name         = "cloudfront_log_source"
+  name         = "cloudfront"
   log_type     = "ACCESS_LOGS"
   resource_arn = aws_cloudfront_distribution.this.arn
 }
 
-resource "aws_cloudwatch_log_delivery_destination" "cloudfront_log_destination" {
+resource "aws_cloudwatch_log_delivery_destination" "this" {
   region = "eu-west-1"
 
-  name          = "cloudfront_log_destination"
+  name          = "s3"
   output_format = "parquet"
 
   delivery_destination_configuration {
-    destination_resource_arn = module.data_aws_core.s3_bucket_log.bucket_domain_name
+    destination_resource_arn = module.data_aws_core.s3_bucket_log.arn
   }
 }
 
-resource "aws_cloudwatch_log_delivery" "cloudfront_log_delivery" {
-  region = "eu-west-1"
+resource "aws_cloudwatch_log_delivery" "this" {
+  region = module.data_aws_core.region
 
-  delivery_source_name     = aws_cloudwatch_log_delivery_source.cloudfront_log_source.name
-  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cloudfront_log_destination.arn
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.this.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.this.arn
 
   s3_delivery_configuration {
-    suffix_path = "/CloudFront/{DistributionId}/{yyyy}/{MM}/{dd}/{HH}"
+    suffix_path = "/cloudfront/{DistributionId}/{yyyy}/{MM}/{dd}/{HH}"
   }
 }
 


### PR DESCRIPTION
Summary

This pull request updates our CloudFront logging configuration from the legacy format to the new V2 logging format. The V2 format offers more flexibility and structure, making it better suited for modern log storage and analysis practices.

Key Improvements
* Hierarchical Log Storage: Enables logs to be stored in a structured directory format organized by year, month, day, and hour.
* Improved Maintainability: Simplifies log navigation, retention, and lifecycle management.
* AWS Best Practices: Aligns with the current AWS-recommended logging standard for CloudFront.

Why This Change?

We attempted to implement a hierarchical folder structure for storing CloudFront logs using the legacy logging format. However, the legacy system does not support this structure, all logs are dumped into a flat namespace (and the hierarchical structure looked like there were no replacement values).

Switching to the V2 logging format resolves this limitation, allowing us to properly organize logs by timestamp and improving both performance and clarity in our observability tooling that depends on these logs. 

Reference on V2 logging: [Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution)