### PR TITLE
feat!: DO-4876: Update block_iframes in spa-tools terraform module to accept an enum

### DIFF
--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -75,7 +75,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
-| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
+| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all) | `string` | `DENY` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_certificate_additional_sans"></a> [certificate\_additional\_sans](#input\_certificate\_additional\_sans) | Additional subject alternative names to include in the certificate | `list(string)` | `[]` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -75,7 +75,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
-| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Should add custom header blocking access via iframes? | `bool` | `true` | no |
+| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. 'all' blocks all iframes (X-Frame-Options: DENY), 'cross\_origin' allows same-origin iframes only (X-Frame-Options: SAMEORIGIN), 'none' allows all iframes (no X-Frame-Options header) | `string` | `"all"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_certificate_additional_sans"></a> [certificate\_additional\_sans](#input\_certificate\_additional\_sans) | Additional subject alternative names to include in the certificate | `list(string)` | `[]` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -75,7 +75,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
-| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all) | `string` | `DENY` | no |
+| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. 'all' blocks all iframes (X-Frame-Options: DENY), 'cross_origin' allows same-origin iframes only (X-Frame-Options: SAMEORIGIN), 'none' allows all iframes (no X-Frame-Options header) | `string` | `all` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_certificate_additional_sans"></a> [certificate\_additional\_sans](#input\_certificate\_additional\_sans) | Additional subject alternative names to include in the certificate | `list(string)` | `[]` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |

--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -75,7 +75,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
-| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all) | `string` | `DENY` | no |
+| <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all) | `string` | `"DENY"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_certificate_additional_sans"></a> [certificate\_additional\_sans](#input\_certificate\_additional\_sans) | Additional subject alternative names to include in the certificate | `list(string)` | `[]` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -180,9 +180,12 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
     content_type_options {
       override = true
     }
-    frame_options {
-      frame_option = var.block_iframes
-      override     = true
+    dynamic "frame_options" {
+      for_each = var.block_iframes != "none" ? [1] : []
+      content {
+        frame_option = var.block_iframes == "all" ? "DENY" : "SAMEORIGIN"
+        override     = true
+      }
     }
     referrer_policy {
       referrer_policy = "same-origin"
@@ -241,9 +244,12 @@ resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour
     content_type_options {
       override = true
     }
-    frame_options {
-      frame_option = var.block_iframes
-      override     = true
+    dynamic "frame_options" {
+      for_each = var.block_iframes != "none" ? [1] : []
+      content {
+        frame_option = var.block_iframes == "all" ? "DENY" : "SAMEORIGIN"
+        override     = true
+      }
     }
     referrer_policy {
       referrer_policy = "same-origin"

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -181,7 +181,7 @@ resource "aws_cloudfront_response_headers_policy" "default_behaviour_headers_pol
       override = true
     }
     frame_options {
-      frame_option = var.block_iframes ? "DENY" : "SAMEORIGIN"
+      frame_option = var.block_iframes
       override     = true
     }
     referrer_policy {
@@ -242,7 +242,7 @@ resource "aws_cloudfront_response_headers_policy" "loading_integration_behaviour
       override = true
     }
     frame_options {
-      frame_option = var.block_iframes ? "DENY" : "SAMEORIGIN"
+      frame_option = var.block_iframes
       override     = true
     }
     referrer_policy {

--- a/terraform-module/modules/frontend-spa-cdn/vars.tf
+++ b/terraform-module/modules/frontend-spa-cdn/vars.tf
@@ -48,12 +48,12 @@ variable "edge_lambdas" {
 }
 
 variable "block_iframes" {
-  description = "Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all)"
-  default     = "DENY"
+  description = "Level of iframe control. 'all' blocks all iframes (X-Frame-Options: DENY), 'cross_origin' allows same-origin iframes only (X-Frame-Options: SAMEORIGIN), 'none' allows all iframes (no X-Frame-Options header)"
+  default     = "all"
   type        = string
   validation {
-    condition     = contains(["DENY", "SAMEORIGIN", "ALLOWALL"], var.block_iframes)
-    error_message = "block_iframes must be one of: DENY, SAMEORIGIN, or ALLOWALL."
+    condition     = contains(["all", "none", "cross_origin"], var.block_iframes)
+    error_message = "block_iframes must be one of: all, none, or cross_origin."
   }
 }
 

--- a/terraform-module/modules/frontend-spa-cdn/vars.tf
+++ b/terraform-module/modules/frontend-spa-cdn/vars.tf
@@ -48,9 +48,13 @@ variable "edge_lambdas" {
 }
 
 variable "block_iframes" {
-  description = "Should add custom header blocking access via iframes?"
-  default     = true
-  type        = bool
+  description = "Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all)"
+  default     = "DENY"
+  type        = string
+  validation {
+    condition     = contains(["DENY", "SAMEORIGIN", "ALLOWALL"], var.block_iframes)
+    error_message = "block_iframes must be one of: DENY, SAMEORIGIN, or ALLOWALL."
+  }
 }
 
 variable "is_robots_indexing_allowed" {

--- a/terraform-module/modules/frontend-spa-edge-lambda/README.md
+++ b/terraform-module/modules/frontend-spa-edge-lambda/README.md
@@ -14,7 +14,7 @@ module "lambda" {
   env                      = "production"
   domain_name              = "hello.example.com"
   default_repo_branch_name = "master"
-  block_iframes            = "DENY"
+  block_iframes            = "all"
   role_arn                 = module.lambda_role.role_arn
   lambda_version           = var.lambdas_version
   bucket_name              = module.s3.bucket_name

--- a/terraform-module/modules/frontend-spa-edge-lambda/README.md
+++ b/terraform-module/modules/frontend-spa-edge-lambda/README.md
@@ -14,7 +14,7 @@ module "lambda" {
   env                      = "production"
   domain_name              = "hello.example.com"
   default_repo_branch_name = "master"
-  block_iframes            = true
+  block_iframes            = "DENY"
   role_arn                 = module.lambda_role.role_arn
   lambda_version           = var.lambdas_version
   bucket_name              = module.s3.bucket_name

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -24,9 +24,13 @@ variable "subdomain" {
 }
 
 variable "block_iframes" {
-  description = "Should add custom header blocking access via iframes?"
-  default     = true
-  type        = bool
+  description = "Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all)"
+  default     = "DENY"
+  type        = string
+  validation {
+    condition     = contains(["DENY", "SAMEORIGIN", "ALLOWALL"], var.block_iframes)
+    error_message = "block_iframes must be one of: DENY, SAMEORIGIN, or ALLOWALL."
+  }
 }
 
 variable "default_repo_branch_name" {

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -24,12 +24,12 @@ variable "subdomain" {
 }
 
 variable "block_iframes" {
-  description = "Level of iframe control. Sets X-Frame-Options header to DENY (block all), SAMEORIGIN (allow same origin), or ALLOWALL (allow all)"
-  default     = "DENY"
+  description = "Level of iframe control. 'all' blocks all iframes (X-Frame-Options: DENY), 'cross_origin' allows same-origin iframes only (X-Frame-Options: SAMEORIGIN), 'none' allows all iframes (no X-Frame-Options header)"
+  default     = "all"
   type        = string
   validation {
-    condition     = contains(["DENY", "SAMEORIGIN", "ALLOWALL"], var.block_iframes)
-    error_message = "block_iframes must be one of: DENY, SAMEORIGIN, or ALLOWALL."
+    condition     = contains(["all", "none", "cross_origin"], var.block_iframes)
+    error_message = "block_iframes must be one of: all, none, or cross_origin."
   }
 }
 


### PR DESCRIPTION
Linear ticket: [DO-4876](https://linear.app/pleo/issue/DO-4876/update-block-iframes-in-spa-tools-terraform-module-to-accept-an-enum)

We got a [bug report](https://linear.app/pleo/issue/DO-4859/telescope-guidelines-figma-plugin-doesnt-seem-to-work) that the Telescope Figma Plugin is broken.

Looking into it, the problem is `X-Frame-Options` header that is set to `SAMEORIGIN`. Figma plugin is embedding telescope.pleo.io inside an iframe and this header blocks it.

In this PR, we're changing `block_iframes` from `bool` to a `string` enum, accepting:
- `all`: blocks all iframes via `X-Frame-Options: DENY`
- `cross_origin`: blocks cross-origin iframes via `X-Frame-Options: SAMEORIGIN`
- `none`: does not set an `X-Frame-Options` header

Changes:
- [frontend-spa-cdn/vars.tf](https://github.com/pleo-io/spa-tools/pull/300/files#diff-f9ade86f5306e7b1473e36ceef56fe808ded7b489e7ea7486e07742d5c998fb0): updated `block_iframes` variable declaration
- [vars.tf](https://github.com/pleo-io/spa-tools/pull/300/files#diff-ca7e889781f851bb66c818c0eaa23a168752a55471a97a438980dd1341455bec): updated `block_iframes` variable declaration
- [frontend-spa-cdn/main.tf](https://github.com/pleo-io/spa-tools/pull/300/files#diff-a5c43731eab6508fccfef7652ada90f3af5ec25b514a788836d0d123fa2f6bec): use `block_iframes` to set `frame_option` - only do it conditionally if `block_iframes` does NOT equal 'none'
- Updated Readme: [frontend-spa-edge-lambda/README.md](https://github.com/pleo-io/spa-tools/pull/300/files#diff-b94dde23138e9144d2c83de26f8d8d0adc103c2b202c9e8cab074d1d233246a0)

A couple of things to sort out:
- [x] ~~does it make sense to still call it `block_iframes` or do we rename the var to `frame_options`?~~ Update: it makes sense to keep `block_iframes` as long as enum values are descriptive (it's a bit of a negation, but that makes sense given the name of the var)
- [x] ~~this is the way to do an enum in terraform?~~ Yes
- [ ] this is the way to do conditionals in terraform? `for_each = var.block_iframes != "none" ? [1] : []` 😅 
- [x] ~~should we set x-frame-options to ALLOWALL if block_iframes is set to allowall or should we rather omit the header completely?~~ Update: `frame_option` only accepts "DENY" and "SAMEORIGIN". Only setting this when `block_iframes` is not "none"