### PR TITLE
fix(frontend-spa-cdn): cloudfront logs

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/README.md
+++ b/terraform-module/modules/frontend-spa-cdn/README.md
@@ -66,3 +66,4 @@ No modules.
 | <a name="output_cf_domain_name"></a> [cf\_domain\_name](#output\_cf\_domain\_name) | n/a |
 | <a name="output_cf_hosted_zone_id"></a> [cf\_hosted\_zone\_id](#output\_cf\_hosted\_zone\_id) | n/a |
 <!-- END_TF_DOCS -->
+

--- a/terraform-module/modules/frontend-spa-cdn/README.md
+++ b/terraform-module/modules/frontend-spa-cdn/README.md
@@ -66,4 +66,3 @@ No modules.
 | <a name="output_cf_domain_name"></a> [cf\_domain\_name](#output\_cf\_domain\_name) | n/a |
 | <a name="output_cf_hosted_zone_id"></a> [cf\_hosted\_zone\_id](#output\_cf\_hosted\_zone\_id) | n/a |
 <!-- END_TF_DOCS -->
-

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -143,15 +143,17 @@ resource "aws_cloudfront_distribution" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_source" "this" {
-  region       = "us-east-1"
-  name         = "cloudfront"
+  region = "us-east-1"
+
+  name         = "cloudfront-${aws_cloudfront_distribution.this.id}"
   log_type     = "ACCESS_LOGS"
   resource_arn = aws_cloudfront_distribution.this.arn
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "this" {
-  region        = "us-east-1"
-  name          = "s3"
+  region = "us-east-1"
+
+  name          = "s3-${module.data_aws_core.s3_bucket_log.id}-${aws_cloudfront_distribution.this.id}"
   output_format = "parquet"
 
   delivery_destination_configuration {
@@ -160,7 +162,8 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery" "this" {
-  region                   = "us-east-1"
+  region = "us-east-1"
+
   delivery_source_name     = aws_cloudwatch_log_delivery_source.this.name
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.this.arn
 


### PR DESCRIPTION
aws_cloudwatch_log_delivery_source and aws_cloudwatch_log_delivery_destination names need to be unique.