### PR TITLE
feat: make cloudwatch access logs optional

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -167,8 +167,8 @@ resource "aws_cloudwatch_log_delivery" "this" {
   count  = var.cloudwatch_access_logs ? 1 : 0
   region = "us-east-1"
 
-  delivery_source_name     = aws_cloudwatch_log_delivery_source.this.name
-  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.this.arn
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.this[count.index].name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.this[count.index].arn
 
   s3_delivery_configuration {
     suffix_path = "/cloudfront/{DistributionId}/{yyyy}/{MM}/{dd}/{HH}"

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -143,6 +143,7 @@ resource "aws_cloudfront_distribution" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_source" "this" {
+  count  = var.cloudwatch_access_logs ? 1 : 0
   region = "us-east-1"
 
   name         = "cloudfront-${aws_cloudfront_distribution.this.id}"
@@ -151,6 +152,7 @@ resource "aws_cloudwatch_log_delivery_source" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery_destination" "this" {
+  count  = var.cloudwatch_access_logs ? 1 : 0
   region = "us-east-1"
 
   name          = "s3-${module.data_aws_core.s3_bucket_log.id}-${aws_cloudfront_distribution.this.id}"
@@ -162,6 +164,7 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
 }
 
 resource "aws_cloudwatch_log_delivery" "this" {
+  count  = var.cloudwatch_access_logs ? 1 : 0
   region = "us-east-1"
 
   delivery_source_name     = aws_cloudwatch_log_delivery_source.this.name

--- a/terraform-module/modules/frontend-spa-cdn/vars.tf
+++ b/terraform-module/modules/frontend-spa-cdn/vars.tf
@@ -61,6 +61,6 @@ variable "is_robots_indexing_allowed" {
 
 variable "cloudwatch_access_logs" {
   description = "Enable CloudWatch access logs"
-  default     = false
+  default     = true
   type        = bool
 }

--- a/terraform-module/modules/frontend-spa-cdn/vars.tf
+++ b/terraform-module/modules/frontend-spa-cdn/vars.tf
@@ -58,3 +58,9 @@ variable "is_robots_indexing_allowed" {
   default     = true
   type        = bool
 }
+
+variable "cloudwatch_access_logs" {
+  description = "Enable CloudWatch access logs"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
currently terraform apply for all web apps are failing because the new cloudfront access logs fail to apply. This makes the cloudwatch logging optional when setting a variable, like that we can unblock the deployment of other changes while we fix the error, without having to constantly roll back changes.

Draft for applying this: https://github.com/pleo-io/terraform/pull/9955
and an apply to dev for the dummy app: https://app.env0.com/p/6fc34fff-98b3-4d5d-bcaa-478ba540216b/environments/abdc35a8-7779-4e6a-8551-c3bced13d25f?tabname=deployment-logs&organizationId=ed3d7d49-aa1a-4456-8ccb-3b56dd0e7070