### PR TITLE
fix(frontend-spa-cdn): Change log format to plain

### DIFF
--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -156,7 +156,7 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
   region = "us-east-1"
 
   name          = "s3-${module.data_aws_core.s3_bucket_log.id}-${aws_cloudfront_distribution.this.id}"
-  output_format = "parquet"
+  output_format = "plain"
 
   delivery_destination_configuration {
     destination_resource_arn = module.data_aws_core.s3_bucket_log.arn

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
   output_format = "plain"
 
   delivery_destination_configuration {
-    destination_resource_arn = "module.data_aws_core.s3_bucket_log.arn/cloudfront/${var.app_name}"
+    destination_resource_arn = "${module.data_aws_core.s3_bucket_log.arn}/cloudfront/${var.app_name}"
   }
 }
 

--- a/terraform-module/modules/frontend-spa-cdn/main.tf
+++ b/terraform-module/modules/frontend-spa-cdn/main.tf
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_log_delivery_destination" "this" {
   output_format = "plain"
 
   delivery_destination_configuration {
-    destination_resource_arn = module.data_aws_core.s3_bucket_log.arn
+    destination_resource_arn = "module.data_aws_core.s3_bucket_log.arn/cloudfront/${var.app_name}"
   }
 }
 


### PR DESCRIPTION
The parquet log format is not supported by Splunk and also incurres extra costs. (They use a lambda in the background to format the logs into parquet).

So we switch to plain logs.