### PR TITLE
fix: race condition when creating lambda archive

### DIFF
--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -20,7 +20,7 @@ resource "local_file" "lambda_config" {
 
 data "archive_file" "lambda" {
   type        = "zip"
-  depends_on  = [local_file.lambda_config]
+  depends_on  = [local_file.lambda_config, local_sensitive_file.lambda_source]
   output_path = "${path.root}/${var.app_name}.${var.event_type}.js.zip"
   source_dir  = "${path.root}/dist/${var.app_name}/${var.event_type}"
 }


### PR DESCRIPTION
Adds the `lambda_source` resource as a dependency to the `archive_file` data source. This should ensure that the lambda source code is bundled into the archive and deployed correctly, fixing the cause of [incident-1505](https://pleo.enterprise.slack.com/archives/C09AXA71NL9).

We were able to confirm that the source code of the viewer-request lambda was empty when we saw the same problem as during the incident for the storybook deployment (see [this thread](https://getpleo.slack.com/archives/C09AXA71NL9/p1755503184052569))

We can also see in env0 logs that during a broken deploy the `archive_file.lambda: Read ...` step was reported before the `lambda_source: Creation complete` was reported.
<img width="2694" height="926" alt="image" src="https://github.com/user-attachments/assets/a77ee9f6-0ca1-40b2-bf86-ff632545c657" />
For a working deploy `lambda_source: Creation complete` is reported first, and it also makes sense that we would need this step finished first
<img width="2674" height="704" alt="image" src="https://github.com/user-attachments/assets/2c2e460c-e6b1-4219-9254-b2f7cb62ff49" />

What's still unclear:
- Why is this depends_on relation not in place already?
  - we won't find an answer to this, this code is unchanged from when it was created in 2022 ([here](https://github.com/pleo-io/pleo-spa-infra/blob/main/terraform-module/modules/frontend-spa-edge-lambda/main.tf#L25))
- Why did this not break before?
  - We have recently updated the AWS provider from version 4 to 6. For me it's still unclear how this would affect these steps in particular because they are core terraform functionality, not from the aws provider
  - i've checked if there was a recent change to the terraform version itself but couldn't find any - the constraint is set to `>=1.5.7` [since 5 months](https://github.com/pleo-io/terraform/commit/f92b74707a258b13016c4d5c410b62d8d550a79f#diff-138700ee73d0dd6b207727fec60577cbd7829cc63236079f28bf7e4a4ad22220) and with all recent deploys including those causing the incident 1.5.7 was the resolved version




