### PR TITLE
feat!: use node 22 in spa-tools edge lambda

### DIFF
--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -34,7 +34,7 @@ resource "aws_lambda_function" "lambda" {
   source_code_hash = data.archive_file.lambda.output_base64sha256
   publish          = true
   role             = var.role_arn
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs22.x"
 
   tags = {
     environment = lower(var.env)


### PR DESCRIPTION
We've updated the node version for the bff lambda to 22 but forgot the edge-lambda in spa-tools, thanks @macko911 for pointing this out. This upgrades the edge lambda as well.