### PR TITLE
feat(terraform-module): support multiple subdomain starting with `partner`

### DIFF
--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -77,7 +77,6 @@ No resources.
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name of the app (kebab-case) | `string` | n/a | yes |
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. 'all' blocks all iframes (X-Frame-Options: DENY), 'cross\_origin' allows same-origin iframes only (X-Frame-Options: SAMEORIGIN), 'none' allows all iframes (no X-Frame-Options header) | `string` | `"all"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
-| <a name="input_certificate_additional_sans"></a> [certificate\_additional\_sans](#input\_certificate\_additional\_sans) | Additional subject alternative names to include in the certificate | `list(string)` | `[]` | no |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
 | <a name="input_is_robots_indexing_allowed"></a> [is\_robots\_indexing\_allowed](#input\_is\_robots\_indexing\_allowed) | Should allow search engine indexing in production? | `bool` | `true` | no |

--- a/terraform-module/edge-lambdas/dist/viewer-request/index.js
+++ b/terraform-module/edge-lambdas/dist/viewer-request/index.js
@@ -481,7 +481,7 @@ async function getAppVersion(request, config, s3) {
     // Preview name is the first segment of the url e.g. my-branch for my-branch.app.dev.example.com
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName;
-    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix)) {
+    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix) && !host.startsWith('partner')) {
         previewName = host.split('.')[0];
         // If the request is for a specific hash of a preview deployment, we use that hash
         const previewHash = getPreviewHash(previewName);

--- a/terraform-module/edge-lambdas/dist/viewer-request/index.js
+++ b/terraform-module/edge-lambdas/dist/viewer-request/index.js
@@ -481,7 +481,9 @@ async function getAppVersion(request, config, s3) {
     // Preview name is the first segment of the url e.g. my-branch for my-branch.app.dev.example.com
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName;
-    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix) && !host.startsWith('partner')) {
+    if (config.previewDeploymentPostfix && host
+        && host.includes(config.previewDeploymentPostfix)
+        && !host.startsWith('partner')) {
         previewName = host.split('.')[0];
         // If the request is for a specific hash of a preview deployment, we use that hash
         const previewHash = getPreviewHash(previewName);

--- a/terraform-module/edge-lambdas/dist/viewer-request/index.js
+++ b/terraform-module/edge-lambdas/dist/viewer-request/index.js
@@ -481,9 +481,10 @@ async function getAppVersion(request, config, s3) {
     // Preview name is the first segment of the url e.g. my-branch for my-branch.app.dev.example.com
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName;
-    if (config.previewDeploymentPostfix && host
-        && host.includes(config.previewDeploymentPostfix)
-        && !host.startsWith('partner')) {
+    if (config.previewDeploymentPostfix &&
+        host &&
+        host.includes(config.previewDeploymentPostfix) &&
+        !host.startsWith('partner')) {
         previewName = host.split('.')[0];
         // If the request is for a specific hash of a preview deployment, we use that hash
         const previewHash = getPreviewHash(previewName);

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -95,7 +95,7 @@ async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3C
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName: string
 
-    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix)) {
+    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix) && !host.startsWith('partner')) {
         previewName = host.split('.')[0]
 
         // If the request is for a specific hash of a preview deployment, we use that hash

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -95,7 +95,9 @@ async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3C
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName: string
 
-    if (config.previewDeploymentPostfix && host && host.includes(config.previewDeploymentPostfix) && !host.startsWith('partner')) {
+    if (config.previewDeploymentPostfix && host
+        && host.includes(config.previewDeploymentPostfix)
+        && !host.startsWith('partner')) {
         previewName = host.split('.')[0]
 
         // If the request is for a specific hash of a preview deployment, we use that hash

--- a/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
+++ b/terraform-module/edge-lambdas/src/viewer-request/viewer-request.ts
@@ -95,9 +95,12 @@ async function getAppVersion(request: CloudFrontRequest, config: Config, s3: S3C
     // Preview name is either a sanitized branch name or it follows the preview-[hash] pattern
     let previewName: string
 
-    if (config.previewDeploymentPostfix && host
-        && host.includes(config.previewDeploymentPostfix)
-        && !host.startsWith('partner')) {
+    if (
+        config.previewDeploymentPostfix &&
+        host &&
+        host.includes(config.previewDeploymentPostfix) &&
+        !host.startsWith('partner')
+    ) {
         previewName = host.split('.')[0]
 
         // If the request is for a specific hash of a preview deployment, we use that hash

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -41,8 +41,6 @@ module "certificate" {
   zone_domain = var.zone_domain
   domain_name = local.domain_name
 
-  additional_subject_alternative_names = var.certificate_additional_sans
-
   providers = {
     aws.global = aws.global
   }

--- a/terraform-module/modules/frontend-spa-certificate/main.tf
+++ b/terraform-module/modules/frontend-spa-certificate/main.tf
@@ -9,16 +9,12 @@ data "aws_route53_zone" "public" {
   private_zone = false
 }
 
-locals {
-  wildcard_san = lower(var.env) == "production" ? [] : ["*.${var.domain_name}"]
-}
-
 resource "aws_acm_certificate" "this" {
   provider          = aws.global
   domain_name       = var.domain_name
   validation_method = "DNS"
 
-  subject_alternative_names = concat(local.wildcard_san, var.additional_subject_alternative_names)
+  subject_alternative_names = lower(var.env) == "production" ? [] : ["*.${var.domain_name}"]
 
   tags = {
     Environment = var.env

--- a/terraform-module/modules/frontend-spa-certificate/vars.tf
+++ b/terraform-module/modules/frontend-spa-certificate/vars.tf
@@ -12,9 +12,3 @@ variable "domain_name" {
   description = "Full domain name of the app"
   type        = string
 }
-
-variable "additional_subject_alternative_names" {
-  description = "Additional subject alternative names to include in the certificate"
-  type        = list(string)
-  default     = []
-}

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -49,9 +49,3 @@ variable "serve_nested_index_html" {
   description = "Applies to apps which build separate index.html files for sub-routes, e.g. using Gatsby SSG"
   type        = bool
 }
-
-variable "certificate_additional_sans" {
-  description = "Additional subject alternative names to include in the certificate"
-  type        = list(string)
-  default     = []
-}


### PR DESCRIPTION
This is for POC of subdomains for embedded.
If subdomain starts with `partner` then we serve content as it was `app.pleo.io`