### PR TITLE
fix(frontend-spa-edge-lambda): store edge lambda in tf state

### DIFF
--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -14,7 +14,7 @@ locals {
 
 data "archive_file" "lambda" {
   type        = "zip"
-  output_path = "/tmp/${var.app_name}.${var.event_type}.zip"
+  output_path = "/tmp/${var.app_name}.${var.event_type}.js.zip"
 
   source {
     content  = local.lambda_source

--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -1,34 +1,36 @@
 # Lambda@Edge lambdas used by the CloudFront distribution's default caching behaviour
 # AWS requires edge lambdas to be deployed to the global region (us-east-1).
 
-# Using local_sensitive_file to avoid Terraform printing the verbose content of the source file
-resource "local_sensitive_file" "lambda_source" {
-  content  = file("${path.module}/../../edge-lambdas/dist/${var.event_type}/index.js")
-  filename = "${path.root}/dist/${var.app_name}/${var.event_type}/index.js"
-}
-
-resource "local_file" "lambda_config" {
-  content = jsonencode({
+locals {
+  lambda_source = file("${path.module}/../../edge-lambdas/dist/${var.event_type}/index.js")
+  lambda_config = jsonencode({
     "originBucketName"         = var.bucket_name
     "originBucketRegion"       = var.bucket_region
     "previewDeploymentPostfix" = var.env == "production" ? "" : ".${var.domain_name}"
     "defaultBranchName"        = var.default_repo_branch_name
     "serveNestedIndexHtml"     = var.serve_nested_index_html
   })
-  filename = "${path.root}/dist/${var.app_name}/${var.event_type}/config.json"
 }
 
 data "archive_file" "lambda" {
   type        = "zip"
-  depends_on  = [local_file.lambda_config, local_sensitive_file.lambda_source]
-  output_path = "${path.root}/${var.app_name}.${var.event_type}.js.zip"
-  source_dir  = "${path.root}/dist/${var.app_name}/${var.event_type}"
+  output_path = "/tmp/${var.app_name}.${var.event_type}.zip"
+
+  source {
+    content  = local.lambda_source
+    filename = "index.js"
+  }
+
+  source {
+    content  = local.lambda_config
+    filename = "config.json"
+  }
 }
 
 resource "aws_lambda_function" "lambda" {
   provider         = aws.global
   description      = "${var.app_name} ${var.event_type} Lambda@Edge"
-  filename         = "${path.root}/${var.app_name}.${var.event_type}.js.zip"
+  filename         = data.archive_file.lambda.output_path
   function_name    = "${var.app_name}-${var.event_type}"
   handler          = "index.handler"
   source_code_hash = data.archive_file.lambda.output_base64sha256
@@ -40,4 +42,3 @@ resource "aws_lambda_function" "lambda" {
     environment = lower(var.env)
   }
 }
-


### PR DESCRIPTION
As a quick fix, until you figure out if and how you want to refactor the deployment pipeline: store edge lambda in tf state to avoid noise at plan time.

Background: Radek showed us the [incident follow-up](https://app.incident.io/getpleo/incidents/1505?tab=post-incident&follow_up_id=01K36AYC6CP55Q1M5XBFBDCSVR) and thought I'd play a bit with this, maybe you can make use of it.