### PR TITLE
chore(ci): move to github runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   semantic-title:
     name: Check PR Title for Semantic Release Type
-    runs-on: ubicloud-standard-2-arm
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     steps:
@@ -31,7 +31,7 @@ jobs:
 
   test-lambdas:
     name: Check Lambda@Edge Functions
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: terraform-module/edge-lambdas

--- a/.github/workflows/close-stale-prs.yaml
+++ b/.github/workflows/close-stale-prs.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -35,7 +35,7 @@ env:
 jobs:
   preflight:
     name: Determine if CodeQL should run
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     outputs:
       should_run_analyze: ${{ steps.maybe_skip_analyze.outputs.should_run_analyze }}
       should_run_wiz_cli: ${{ steps.maybe_skip_wiz_cli.outputs.should_run_wiz_cli }}
@@ -87,7 +87,7 @@ jobs:
     if: ${{ needs.preflight.outputs.should_run_wiz_cli == 'true'}}
     needs:
       - preflight
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pr-help.yaml
+++ b/.github/workflows/pr-help.yaml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   auto-approve-pr:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     name: Auto-approve PR
     if: ${{ contains(fromJSON('["pleo-bot-renovate", "pleo-file-distributor[bot]"]'), github.actor) && contains(github.event.pull_request.labels.*.name, 'autoapprove') }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   release:
     name: Run "Release Please"
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3.7.8
         id: release

--- a/.github/workflows/tf-docs.yml
+++ b/.github/workflows/tf-docs.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   docs:
     name: Generate and Commit Terraform Modules Docs
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
We've decided to move forward with blacksmith. Unfortunately, we still have commitment with Github and we need to spend quite a lot of minutes on Github runners. 
Because of this we are moving web repo to Github runners with plan to move to blacksmith in 2027.

Context with analysis: https://www.notion.so/pleo/Github-runners-comparison-31053cae7a6680d6b393dd1f863de461