### PR TITLE
chore: upgrade gradle/actions/setup-gradle to v6.1.0 with basic cache provider

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -150,9 +150,12 @@ jobs:
 
       # Allow caching Gradle executions to further speed up CI/CD steps invoking Gradle.
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         if: ${{ env.WORKING_LANGUAGE == 'java' }}
         with:
+          # Use open-source caching to avoid the proprietary "Enhanced Caching" introduced as default in v6.
+          # See https://blog.gradle.org/choice-clarity-future-caching-gradle-actions
+          cache-provider: basic
           gradle-version: wrapper
           cache-read-only: true
 


### PR DESCRIPTION
## Summary
- Upgrades `gradle/actions/setup-gradle` to v6.1.0
- Adds `cache-provider: basic` to opt out of the proprietary "Enhanced Caching" introduced as the default in v6

Closes [CORE-342](https://linear.app/pleo/issue/CORE-342)

## Test plan
- [ ] Verify CI passes after merge