### PR TITLE
feat(frontend-github-deployment-env): add BFF_DEPLOYER_ROLE_ARN var

### DIFF
--- a/terraform-module/modules/frontend-github-deployment-env/main.tf
+++ b/terraform-module/modules/frontend-github-deployment-env/main.tf
@@ -27,3 +27,11 @@ resource "github_actions_environment_secret" "secret_access_key" {
   secret_name     = "AWS_SECRET_ACCESS_KEY"
   plaintext_value = var.access_key_secret
 }
+
+resource "github_actions_environment_variable" "bff_deployer_role_arn" {
+  count         = var.bff_deployer_role_arn == null ? 0 : 1
+  repository    = var.repo_name
+  environment   = github_repository_environment.this.environment
+  variable_name = "BFF_DEPLOYER_ROLE_ARN"
+  value         = var.bff_deployer_role_arn
+}

--- a/terraform-module/modules/frontend-github-deployment-env/variables.tf
+++ b/terraform-module/modules/frontend-github-deployment-env/variables.tf
@@ -29,3 +29,9 @@ variable "reviewer_teams" {
   type        = list(string)
   default     = []
 }
+
+variable "bff_deployer_role_arn" {
+  description = "ARN of the AWS IAM role to assume for BFF deployments via GitHub OIDC. When set, exposed to the GitHub environment as vars.BFF_DEPLOYER_ROLE_ARN so the BFF deploy workflow can use OIDC instead of the static AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY secrets."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

Adds an optional `bff_deployer_role_arn` input to the `frontend-github-deployment-env` module. When set, it creates a GitHub Actions environment variable `BFF_DEPLOYER_ROLE_ARN` on the target environment, exposing the ARN to workflows that run against that environment.

## Why

In pleo-io/web, the BFF deploy workflow (`reusable_bff-deploy.yml`) needs to configure AWS credentials differently per GitHub environment (product-dev / staging / production live in different AWS accounts). A previous attempt (pleo-io/web#28054, reverted in #28549) hardcoded a single role ARN for all three environments, which caused product-dev deploys to land in the staging AWS account and broke auth for everyone on product-dev.

The companion web PR (pleo-io/web#28564) switches `reusable_bff-deploy.yml` to prefer OIDC when `vars.BFF_DEPLOYER_ROLE_ARN` is set on the GH env, falling back to the existing static keys when it isn't. This module change is what actually populates that var per env.

## How callers use it

In the `terraform` repo, each per-app deployer already creates a `deployer_role` IAM role scoped to the TF workspace's AWS account. Callers just pass it through:

```hcl
module "deployment_envs" {
  # ...
  bff_deployer_role_arn = aws_iam_role.deployer_role.arn
}
```

Because each TF workspace runs against a single AWS account, the ARN is automatically correct for every environment that workspace manages.

When the input is left unset (default), the module behaves exactly as before — no GH env variable is created.

## Testing

- [ ] `terraform plan` in `terraform/components/product-web` (all three workspaces) against a branch-pinned version of this module shows only the addition of one `github_actions_environment_variable` per env
- [ ] After release, bump `pleo-io/terraform` pin to the new tag and verify the var appears on the target GH environments
