### PR TITLE
feat: add optional lifecycle rule to clean up old deploys

### DIFF
--- a/terraform-module/README.md
+++ b/terraform-module/README.md
@@ -78,6 +78,7 @@ No resources.
 | <a name="input_block_iframes"></a> [block\_iframes](#input\_block\_iframes) | Level of iframe control. 'all' blocks all iframes (Content-Security-Policy: frame-ancestors 'none'), 'cross\_origin' allows same-origin iframes only (Content-Security-Policy: frame-ancestors 'self'), 'none' allows all iframes (no Content-Security-Policy header) | `string` | `"all"` | no |
 | <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | Prefix for the bucket name. Since S3 bucket live in global scope, it's good prefix it with e.g. your org name | `string` | n/a | yes |
 | <a name="input_default_repo_branch_name"></a> [default\_repo\_branch\_name](#input\_default\_repo\_branch\_name) | Name of the default branch of the project repo | `string` | `"master"` | no |
+| <a name="input_delete_old_deploys_after_days"></a> [delete\_old\_deploys\_after\_days](#input\_delete\_old\_deploys\_after\_days) | Number of days after which old deployment files in S3 are deleted via a lifecycle rule. null (default) disables the rule. | `number` | `null` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment (production/staging) | `string` | n/a | yes |
 | <a name="input_is_robots_indexing_allowed"></a> [is\_robots\_indexing\_allowed](#input\_is\_robots\_indexing\_allowed) | Should allow search engine indexing in production? | `bool` | `true` | no |
 | <a name="input_partners"></a> [partners](#input\_partners) | Map of partner subdomains to their config (slug used for theme CSS filename) | `map(object({slug = string}))` | `{}` | no |

--- a/terraform-module/main.tf
+++ b/terraform-module/main.tf
@@ -3,10 +3,11 @@ locals {
 }
 
 module "s3" {
-  source        = "./modules/frontend-spa-s3"
-  app_name      = var.app_name
-  bucket_prefix = var.bucket_prefix
-  env           = var.env
+  source                        = "./modules/frontend-spa-s3"
+  app_name                      = var.app_name
+  bucket_prefix                 = var.bucket_prefix
+  env                           = var.env
+  delete_old_deploys_after_days = var.delete_old_deploys_after_days
 }
 
 module "lambda_role" {

--- a/terraform-module/modules/frontend-spa-s3/main.tf
+++ b/terraform-module/modules/frontend-spa-s3/main.tf
@@ -93,3 +93,17 @@ resource "aws_s3_bucket_policy" "oai_read" {
   bucket = aws_s3_bucket.origin.id
   policy = data.aws_iam_policy_document.s3_policy.json
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "old_deploys_cleanup" {
+  count  = var.delete_old_deploys_after_days != null ? 1 : 0
+  bucket = aws_s3_bucket.origin.id
+
+  rule {
+    id     = "delete-old-deploys"
+    status = "Enabled"
+
+    expiration {
+      days = var.delete_old_deploys_after_days
+    }
+  }
+}

--- a/terraform-module/modules/frontend-spa-s3/vars.tf
+++ b/terraform-module/modules/frontend-spa-s3/vars.tf
@@ -12,3 +12,9 @@ variable "app_name" {
   type        = string
 }
 
+variable "delete_old_deploys_after_days" {
+  description = "Number of days after which old deployment files are deleted via a lifecycle rule. null disables the rule."
+  type        = number
+  default     = null
+  nullable    = true
+}

--- a/terraform-module/modules/frontend-spa-s3/vars.tf
+++ b/terraform-module/modules/frontend-spa-s3/vars.tf
@@ -13,7 +13,7 @@ variable "app_name" {
 }
 
 variable "delete_old_deploys_after_days" {
-  description = "Number of days after which old deployment files are deleted via a lifecycle rule. null disables the rule."
+  description = "Number of days after which old deployment files are deleted via a lifecycle rule. !!WARNING!! Avoid this in production environments - if there are no new deployments the latest deployment will be deleted"
   type        = number
   default     = null
   nullable    = true

--- a/terraform-module/vars.tf
+++ b/terraform-module/vars.tf
@@ -55,3 +55,10 @@ variable "partners" {
   type        = map(object({slug = string}))
   default     = {}
 }
+
+variable "delete_old_deploys_after_days" {
+  description = "Number of days after which old deployment files in S3 are deleted via a lifecycle rule. null (default) disables the rule."
+  type        = number
+  default     = null
+  nullable    = true
+}


### PR DESCRIPTION
adds optional lifecycle rule to our origin buckets for cleaning up old deploys.
the plan is to set this to something like 30 days for dev deploys, and keep it disabled for staging and production.

background is that we're keeping all dev deploys since the repo was created and never clean anything up, which has accumulated 5+ terabytes of files. recently we wanted to delete all sourcemap files from dev, but this is not feasible with the amount of files (it would take more than 6 full days to run the script)

it is safe to clean up old files because on each deploy we overwrite all static assets, so if a file with the same content hash from an older deploy already exists it will get a recent updated-at date. i've verified that by having claude create this script: https://github.com/pleo-io/web/compare/claude/great-mcclintock?expand=1#diff-8ec7b52fe375fc404a665c3ab6c7fc9b581f9e7be5aa89a6a6d7803c41d1c5be
it will download all static assets and check that the updated-at date is close to the deployment date.
output from this script with a recent deploy:

```
❯ npx tsx scripts/verify-deploy-timestamps.ts pleo-product-web-origin-product-dev df7f2424afa06a5c
Deploy hash: df7f2424afa06a5c
Bucket: pleo-product-web-origin-product-dev
Stale threshold: 3600s

Downloading HTML files for deploy...
Found 4 HTML file(s)
Deploy time: 2026-04-23T10:49:59.000Z

Extracting static asset references from HTML...
Found 6 unique static references in HTML
Following JS imports to find code-split chunks...
Found 897 additional references from JS entry bundles
Total unique static references: 903

Checking LastModified timestamps...
===== Results =====                                         
Deploy hash: df7f2424afa06a5c
Deploy time: 2026-04-23T10:49:59.000Z
Total static files checked: 903

  OK     903 files have LastModified within 3600s of deploy

SUCCESS: All 903 static files have fresh timestamps.
Age-based S3 lifecycle rules are safe for this deploy.
```
