### PR TITLE
feat(SRE-8084): cloudwatch log group retention

### DIFF
--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -65,7 +65,7 @@ resource "aws_lambda_function" "lambda" {
 # To ensure PCI-DSS compliance (retention + tagging), we pre-provision these log groups  
 # across all regions covered by our CloudFront Price Class.
 locals {
-  # PriceClass_100 (see ../bff-cdn/vars.tf:L26) limits traffic to North America and Europe.
+  # PriceClass_100 limits traffic to North America and Europe.
   # We pre-deploy log groups in these specific AWS regions to prevent 
   # AWS from auto-creating them with "Infinite" retention.
   target_regions = [

--- a/terraform-module/modules/frontend-spa-edge-lambda/main.tf
+++ b/terraform-module/modules/frontend-spa-edge-lambda/main.tf
@@ -57,7 +57,30 @@ resource "aws_lambda_function" "lambda" {
   depends_on = [aws_cloudwatch_log_group.lambda]
 }
 
+# CloudWatch Log Groups for Lambda@Edge
+# 
+# Lambda@Edge does not stream logs back to the region where the function was deployed (us-east-1).
+# Instead, it creates regional log groups in the viewer's closest region. 
+#
+# To ensure PCI-DSS compliance (retention + tagging), we pre-provision these log groups  
+# across all regions covered by our CloudFront Price Class.
+locals {
+  # PriceClass_100 (see ../bff-cdn/vars.tf:L26) limits traffic to North America and Europe.
+  # We pre-deploy log groups in these specific AWS regions to prevent 
+  # AWS from auto-creating them with "Infinite" retention.
+  target_regions = [
+    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+    "eu-west-1", "eu-west-2", "eu-central-1"
+  ]
+}
+
 resource "aws_cloudwatch_log_group" "lambda" {
+  for_each = toset(local.target_regions)
+
+  region = each.key
+
+  # Naming Convention: Lambda@Edge runtime expects the log group to be prefixed 
+  # with the function's home region (always us-east-1 for Lambda@Edge).
   name              = "/aws/lambda/us-east-1.${local.function_name}"
   retention_in_days = module.data_aws_core.log_expiry_in_days
 


### PR DESCRIPTION
Linear Issue: [SRE-8084](https://linear.app/pleo/issue/SRE-8084/update-cloudwatch-log-groups-to-retain-12-months-of-data-instead)

## Summary

We need to enforce retention on all cloudwatch log groups for PCI-DSS compliance.
Currently, the log groups that are automagically created by Lambda@Edge are not configured with retention, this is a known bug from AWS, the quick fix is to pre-deploy the log groups in all the regions the Lambdas can be called in.

Related PR https://github.com/pleo-io/bff-tools/pull/549
